### PR TITLE
change server port for test (arch dependent)

### DIFF
--- a/tests/server_test.inc
+++ b/tests/server_test.inc
@@ -1,7 +1,7 @@
 <?php
 /* based on sapi/cli/tests/php_cli_server.inc */
 define ("PHP_CLI_SERVER_HOSTNAME", "127.0.0.1");
-define ("PHP_CLI_SERVER_PORT", 8000);
+define ("PHP_CLI_SERVER_PORT", 8000+PHP_INT_SIZE);
 define ("PHP_CLI_SERVER_ADDRESS", PHP_CLI_SERVER_HOSTNAME.":".PHP_CLI_SERVER_PORT);
 
 /* XXX incapsulate all this globals into a class when have a favourable minute */


### PR DESCRIPTION
When building packages, test suite may fails when 32 and 64 bits build are running on the same computer.

This minor trivial change fixes this, using port 8004 (on 32 bits) and 8008 (on 64 bits) instead of 8000.
