### PR TITLE
Fix variable typo in config.m4 for php_cv_semun

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -90,7 +90,7 @@ if test "$PHP_APCU" != "no"; then
 #include <sys/ipc.h>
 #include <sys/sem.h>
     ], [union semun x; x.val=1], [
-      hp_cv_semun=yesp
+      php_cv_semun=yes
     ],[
       php_cv_semun=no
     ])


### PR DESCRIPTION
Removes a bunch of compiler warnings.
