### PR TITLE
Error level for the case of what cache is outdated and its reference remains

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -209,7 +209,7 @@ PHP_APCU_API void apc_cache_gc(apc_cache_t* cache TSRMLS_DC)
 
 				/* good ol' whining */
 			    if (dead->value->ref_count > 0) {
-			        apc_warning(
+			        apc_debug(
 						"GC cache entry '%s' was on gc-list for %d seconds" TSRMLS_CC, 
 						dead->key.str, gc_sec
 					);


### PR DESCRIPTION
When `cache->gc_ttl` is outdated and reference to cache item remains,

**apc_cache_gc** prints warning message. ("GC cache entry '%s' was on gc-list for %d seconds")

But this situation should be treated as not warning but debug or notice.

Bacause this situation often occurs for real and PHP & APCu still can continue without problem.
