### PR TITLE
Fix config.m4 --enable-apcu-{rwlocks,mmap}

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -19,14 +19,8 @@ AC_MSG_RESULT($PHP_APC_BC)
 AC_MSG_CHECKING(if APCu should be allowed to use rwlocks)
 AC_ARG_ENABLE(apcu-rwlocks,
 [  --disable-apcu-rwlocks  Disable rwlocks in APCu],
-[
-  PHP_APCU_RWLOCKS=no
-  AC_MSG_RESULT(no)
-],
-[
-  PHP_APCU_RWLOCKS=yes
-  AC_MSG_RESULT(yes)
-])
+[ PHP_APCU_RWLOCKS="$enableval" ], [ PHP_APCU_RWLOCKS=yes ])
+AC_MSG_RESULT($PHP_APCU_RWLOCKS)
 
 AC_MSG_CHECKING(if APCu should be built in debug mode)
 AC_ARG_ENABLE(apcu-debug,
@@ -53,13 +47,12 @@ AC_ARG_ENABLE(apcu-clear-signal,
 AC_MSG_CHECKING(if APCu will use mmap or shm)
 AC_ARG_ENABLE(apcu-mmap,
 [  --disable-apcu-mmap     Disable mmap, falls back on shm],
-[
-  PHP_APCU_MMAP=no
+[ PHP_APCU_MMAP="$enableval" ], [ PHP_APCU_MMAP=yes ])
+if test "x$enableval" = "xno"; then
   AC_MSG_RESULT(shm)
-], [
-  PHP_APCU_MMAP=yes
+else
   AC_MSG_RESULT(mmap)
-])
+fi
 
 PHP_APCU_SPINLOCK=no
 AC_MSG_CHECKING(if APCu should utilize spinlocks before flocks)


### PR DESCRIPTION
## --**enable**-apcu-{rwlocks,mmap} _disables_ feature

This patch fixes those cases, enabling mmap and rwlocks by default.

### Before:

```sh
# rwlocks
$ ./configure | grep rwlocks
checking if APCu should be allowed to use rwlocks... yes
configure: WARNING: APCu has access to native rwlocks

$ ./configure --enable-apcu-rwlocks | grep rwlocks
checking if APCu should be allowed to use rwlocks... no
configure: WARNING: APCu has access to mutexes

$ ./configure --disable-apcu-rwlocks | grep rwlocks
checking if APCu should be allowed to use rwlocks... no
configure: WARNING: APCu has access to mutexes

# mmap
$ ./configure | grep mmap
checking if APCu will use mmap or shm... mmap

$ ./configure --enable-apcu-mmap | grep mmap
checking if APCu will use mmap or shm... shm

$ ./configure --disable-apcu-mmap | grep mmap
checking if APCu will use mmap or shm... shm
```

### After:

```sh
# rwlocks
$ ./configure | grep rwlocks
checking if APCu should be allowed to use rwlocks... yes
configure: WARNING: APCu has access to native rwlocks

./configure --enable-apcu-rwlocks | grep rwlocks
checking if APCu should be allowed to use rwlocks... yes
configure: WARNING: APCu has access to native rwlocks

$ ./configure --disable-apcu-rwlocks | grep rwlocks
checking if APCu should be allowed to use rwlocks... no
configure: WARNING: APCu has access to mutexes

# mmap
$ ./configure | grep mmap
checking if APCu will use mmap or shm... mmap

$ ./configure --enable-apcu-mmap | grep mmap
checking if APCu will use mmap or shm... mmap

$ ./configure --disable-apcu-mmap | grep mmap
checking if APCu will use mmap or shm... shm
```