### PR TITLE
Convert values to HTML entities before outputting

### DIFF
--- a/apc.php
+++ b/apc.php
@@ -1049,7 +1049,7 @@ EOB;
         echo '</tr>';
 		if ($sh == $MYREQUEST["SH"]) {
 			echo '<tr>';
-			echo '<td colspan="7"><pre>'.print_r(apcu_fetch($entry['key']), 1).'</pre></td>';
+			echo '<td colspan="7"><pre>'.htmlentities(print_r(apcu_fetch($entry['key']), 1)).'</pre></td>';
 			echo '</tr>';
 		}
         $i++;


### PR DESCRIPTION
Avoids the page messing up when HTML is used in the value of a key.
