### PR TITLE
Fix PHP 5.4 build

### DIFF
--- a/apc_bin.c
+++ b/apc_bin.c
@@ -34,6 +34,12 @@
 
 #include "ext/standard/md5.h"
 
+#ifdef HAVE_PTRDIFF_T
+#include <stddef.h>
+#else
+typedef long ptrdiff_t;
+#endif
+
 /* in apc_cache.c */
 extern zval* apc_copy_zval(zval* dst, const zval* src, apc_context_t* ctxt TSRMLS_DC);
 


### PR DESCRIPTION
With PHP 5.4

```
/builddir/build/BUILD/php-pecl-apcu-4.0.5/NTS/apc_bin.c: In function '_apc_swizzle_ptr':
/builddir/build/BUILD/php-pecl-apcu-4.0.5/NTS/apc_bin.c:151:13: error: 'ptrdiff_t' undeclared (first use in this function)
         if((ptrdiff_t)bd < (ptrdiff_t)*ptr && (size_t)*ptr < ((size_t)bd + bd->size)) {
```

This seems related to missing include (don't really find the diff between 5.4 and 5.5+...)
As ptrdiff_t is known as not portable, the #else should fix the portability.
