### PR TITLE
Fixes $cache key names where needed

### DIFF
--- a/apc.php
+++ b/apc.php
@@ -988,6 +988,11 @@ EOB;
 	$list = array();
 
 	foreach($cache[$scope_list[$MYREQUEST['SCOPE']]] as $i => $entry) {
+		$entry['info']=$entry['info']?:$entry['key'];
+		$entry['access_time']=$entry['access_time']?:$entry['atime'];
+		$entry['deletion_time']=$entry['deletion_time']?:$entry['dtime'];
+		$entry['creation_time']=$entry['creation_time']?:$entry['ctime'];
+		$entry['num_hits']=$entry['num_hits']?:$entry['nhits'];		
 		switch($MYREQUEST['SORT1']) {
 			case 'A': $k=sprintf('%015d-',$entry['access_time']);  	    break;
 			case 'H': $k=sprintf('%015d-',$entry['num_hits']); 		    break;


### PR DESCRIPTION
Apparently some keys in the $cache array changed names, so nothing was displayed in the control panel for user variables.

This pull request fixes the following keys:
- key instead of info
- atime instead of access_time
- dtime instead of deletion_time
- ctime instead of creation_time
- nhits instead of num_hits

The replacement is done only where needed. i.e. if the array keys somehow go back to their old form, they'll be left untouched.
