### PR TITLE
Add compatibility with newer versions of apcu in apc.php

### DIFF
--- a/apc.php
+++ b/apc.php
@@ -187,6 +187,21 @@ if(!function_exists('apcu_cache_info')) {
 
 $cache = apcu_cache_info();
 
+function rename_cache_info($cache) {
+    // add compatibility with old and new versions of apc info reported in $cache
+    $names = array( 'num_hits' => 'nhits', 'num_misses' => 'nmisses', 'num_entries' => 'nentries', 'num_expunges' => 'nexpunges', 'num_inserts' => 'ninserts',
+                    'start_time' => 'stime', 'deletion_time' => 'dtime', 'modification_time' => 'mtime', 'creation_time' => 'ctime', 'access_time' => 'atime',
+                    'info' => 'key' );
+    foreach ($names as $old => $new) {
+        if (!isset($cache[$old]) && isset($cache[$new])) { $cache[$old] = $cache[$new]; }
+        foreach ($cache['cache_list'] as &$cacheListItem) {
+            if (!isset($cacheListItem[$old]) && isset($cacheListItem[$new])) $cacheListItem[$old] = $cacheListItem[$new];
+        }
+    }
+    return $cache;
+}
+$cache = rename_cache_info($cache);
+
 $mem=apcu_sma_info();
 
 // don't cache this page


### PR DESCRIPTION
Was seeing a lot of PHP notices for undefined variables in PHP5.5.18 and above because apcu_cache_info() was returning an array of information that did not match what the code expected. It is expecting a result from apc_cache_info() (note different function name). Added a "compatibility" function that turns newer $cache info keys into older ones so that apc.php will work with both
