### PR TITLE
Windows fixes

### DIFF
--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -86,7 +86,7 @@ typedef struct _apc_cache_header_t {
     zend_long nentries;             /* entry count */
     zend_long mem_size;             /* used */
     time_t stime;                    /* start time */
-    ushort state;                    /* cache state */
+    unsigned short state;            /* cache state */
     apc_cache_key_t lastkey;         /* last key inserted (not necessarily without error) */
     apc_cache_slot_t* gc;            /* gc list */
 } apc_cache_header_t; /* }}} */

--- a/config.w32
+++ b/config.w32
@@ -7,7 +7,7 @@ ARG_ENABLE('apc-bc', 'Whether APCu should provide APC full compatibility support
 
 if(PHP_APCU != 'no')
 {
-	var apc_sources = 	'apc.c apc_lock.c php_apc.c ' +
+	var apc_sources = 	'apc.c apc_lock.c apc_windows_srwlock_kernel.c php_apc.c ' +
 						'apc_cache.c ' +
 						'apc_mmap.c ' +
 						'apc_shm.c ' +


### PR DESCRIPTION
Silly fix: you were the only one that used ushort in stead of unsigned short. 'typedef unsigned short ushort;' would have been a solution, but better make it generic and use 'unsigned short' on all platforms.

And I added apc_windows_srwlock_kernel.c in config.w32.

php_apcu.dll compiles on Windows now as well. I did not run the tests yet, though.