### PR TITLE
Fixed build with BC disabled 

### DIFF
--- a/php_apc.c
+++ b/php_apc.c
@@ -402,7 +402,7 @@ PHP_FUNCTION(apcu_clear_cache)
 /* {{{ proto array apc_cache_info([bool limited]) */
 PHP_FUNCTION(apcu_cache_info)
 {
-    zval* info;
+    zval info;
     zend_bool limited = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &limited) == FAILURE) {
@@ -411,12 +411,12 @@ PHP_FUNCTION(apcu_cache_info)
 
     info = apc_cache_info(apc_user_cache, limited);
 
-    if (!info) {
+    if (Z_TYPE(info) != IS_ARRAY) {
         php_error_docref(NULL, E_WARNING, "No APC info available.  Perhaps APC is not enabled? Check apc.enabled in your ini file");
         RETURN_FALSE;
     }
 
-    RETURN_ZVAL(info, 0, 1);
+    RETURN_ZVAL(&info, 0, 0);
 
 }
 /* }}} */
@@ -1055,6 +1055,7 @@ zend_module_entry apcu_module_entry = {
     PHP_APCU_VERSION,
     STANDARD_MODULE_PROPERTIES
 };
+/* }}} */
 
 #ifdef APC_FULL_BC
 
@@ -1080,6 +1081,7 @@ zend_function_entry apc_functions[] = {
     PHP_FALIAS(apc_exists,       apcu_exists,       arginfo_apcu_exists)
     {NULL, NULL, NULL}
 };
+/* }}} */
 
 zend_module_entry apc_module_entry = {
 	STANDARD_MODULE_HEADER,


### PR DESCRIPTION
The patch just fixes the code so that it would compile with PHP7.

But I must note that BC doesn't quite work - changing the module hash from within hash_apply() produces these warnings and a crash for me:

==32026== Invalid read of size 1
==32026==    at 0x63F3C0: zend_hash_apply (zend_hash.c:1459)
==32026==    by 0x631DF9: zend_startup_modules (zend_API.c:1955)
==32026==    by 0x5D00C5: php_module_startup (main.c:2194)
==32026==    by 0x6C64C4: php_cgi_startup (fpm_main.c:837)
==32026==    by 0x42DADC: main (fpm_main.c:1788)
==32026==  Address 0x74bbff8 is 8 bytes after a block of size 1,152 free'd
==32026==    at 0x4C2970C: free (vg_replace_malloc.c:468)
==32026==    by 0x6391C4: zend_hash_do_resize (zend_hash.c:825)
==32026==    by 0x639BB7: _zend_hash_add (zend_hash.c:536)
==32026==    by 0x633862: zend_register_module_ex (zend_hash.h:546)
==32026==    by 0xCD35FED: apc_init (php_apc.c:1116)
==32026==    by 0xCD348A6: zm_startup_apcu (php_apc.c:304)
==32026==    by 0x631A81: zend_startup_module_ex (zend_API.c:1829)
==32026==    by 0x63F3D1: zend_hash_apply (zend_hash.c:1460)
==32026==    by 0x631DF9: zend_startup_modules (zend_API.c:1955)
==32026==    by 0x5D00C5: php_module_startup (main.c:2194)
==32026==    by 0x6C64C4: php_cgi_startup (fpm_main.c:837)
==32026==    by 0x42DADC: main (fpm_main.c:1788)
