### PR TITLE
apcu_inc/dec should create missing cache entries

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -987,6 +987,7 @@ PHP_APCU_API apc_cache_entry_t* apc_cache_exists(apc_cache_t* cache, zend_string
 PHP_APCU_API zend_bool apc_cache_update(apc_cache_t* cache, zend_string *key, apc_cache_updater_t updater, void* data)
 {
     apc_cache_slot_t** slot;
+    apc_cache_entry_t tmp_entry;
 	
     zend_bool retval = 0;
     zend_ulong h, s;
@@ -1041,9 +1042,17 @@ PHP_APCU_API zend_bool apc_cache_update(apc_cache_t* cache, zend_string *key, ap
 		/* set next slot */
         slot = &(*slot)->next;
 	}
-	
+
 	/* unlock header */
 	APC_UNLOCK(cache->header);
+
+	/* failed to find matching entry, create it */
+	ZVAL_LONG(&tmp_entry.val, 0);
+	updater(cache, &tmp_entry, data);
+
+	if(apc_cache_store(cache, key, &tmp_entry.val, 0, 0)) {
+		return 1;
+	}
 
     return 0;
 }


### PR DESCRIPTION
At the moment apcu_dec/inc() return FALSE when the entry they modify doesn't exist. This patch changes this behavior - they'll create missing entry and assign it 'step' value.