### PR TITLE
Fix memory leak/failed check for duplicates when serializing arrays and object

### DIFF
--- a/tests/apc_005b.phpt
+++ b/tests/apc_005b.phpt
@@ -1,0 +1,51 @@
+--TEST--
+APC: apcu_store/fetch with arrays with duplicate object
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.file_update_protection=0
+--FILE--
+<?php
+
+$o = new stdClass();
+$foo = array($o, $o);
+
+var_dump($foo);
+
+apcu_store('foo',$foo);
+
+$bar = apcu_fetch('foo');
+var_dump($foo);
+// $bar[0] should be identical to $bar[1], and not a reference
+var_dump($bar);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  object(stdClass)#1 (0) {
+  }
+  [1]=>
+  object(stdClass)#1 (0) {
+  }
+}
+array(2) {
+  [0]=>
+  object(stdClass)#1 (0) {
+  }
+  [1]=>
+  object(stdClass)#1 (0) {
+  }
+}
+array(2) {
+  [0]=>
+  object(stdClass)#2 (0) {
+  }
+  [1]=>
+  object(stdClass)#2 (0) {
+  }
+}
+===DONE===

--- a/tests/apc_005c.phpt
+++ b/tests/apc_005c.phpt
@@ -1,0 +1,59 @@
+--TEST--
+APC: apcu_store/fetch with arrays with two object references
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.file_update_protection=0
+--FILE--
+<?php
+
+$o = new stdClass();
+$foo = array(&$o, &$o);
+
+var_dump($foo);
+
+apcu_store('foo',$foo);
+
+$bar = apcu_fetch('foo');
+var_dump($foo);
+// $bar[0] should be a reference to $bar[1].
+var_dump($bar);
+$bar[0] = 'roh';
+var_dump($bar);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  &object(stdClass)#1 (0) {
+  }
+  [1]=>
+  &object(stdClass)#1 (0) {
+  }
+}
+array(2) {
+  [0]=>
+  &object(stdClass)#1 (0) {
+  }
+  [1]=>
+  &object(stdClass)#1 (0) {
+  }
+}
+array(2) {
+  [0]=>
+  &object(stdClass)#2 (0) {
+  }
+  [1]=>
+  &object(stdClass)#2 (0) {
+  }
+}
+array(2) {
+  [0]=>
+  &string(3) "roh"
+  [1]=>
+  &string(3) "roh"
+}
+===DONE===


### PR DESCRIPTION
Affects built in serializer as well as the igbinary7 serializer.

The apc serialization/unserialization code was checking
IS_REFCOUNTED_P(val).
However, when objects were being serialized as strings, the 
IS_REFCOUNTED bit in the type flags wasn't being set (Bitmask was 0)

This meant that if there were two uses of an object being serialized, it would be
cloned, since the code treated `dst` as if it couldn't be refcounted, and 
thus didn't add the mapping from `src`'s zend_refcounted pointer to `dst` into
`si->copied`

Found this bug while working on https://github.com/igbinary/igbinary7/pull/23
