### PR TITLE
Print error message if an invalid zend_type is encountered when serializing/unserializing

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -1555,6 +1555,7 @@ static APC_HOTSPOT zval* my_copy_zval(zval* dst, const zval* src, apc_context_t*
 		}
 	}
 
+    /* Handle copying types types listed in https://wiki.php.net/phpng-int */
     switch (Z_TYPE_P(src)) {
     case IS_RESOURCE:
     case IS_TRUE:
@@ -1604,13 +1605,10 @@ static APC_HOTSPOT zval* my_copy_zval(zval* dst, const zval* src, apc_context_t*
             return NULL;
         break;
 
-    case IS_CALLABLE:
-        /* XXX implement this */
-        assert(0);
-        break;
-
     default:
-        assert(0);
+        /* This should never happen, unless we are passed corrupt data or new types are added */
+        zend_error(E_WARNING, "APCU: my_copy_zval (ctx->copy = %d): encountered unrecognized zval type %d", (int) ctxt->copy, (int) Z_TYPE_P(src));
+        ZVAL_NULL(dst);
     }
 
 	if (Z_REFCOUNTED_P(dst) && ctxt->copied.nTableSize) {


### PR DESCRIPTION
Also, remove IS_CALLABLE. It's used for type hints.
It's not used anywhere for `zval` values.
E.g.

```c
Zend/zend_compile.c
4560:                           } else if (arg_info->type_hint ==
IS_CALLABLE && default_ast) {
```

assert() is replaced with a no-op in non-debug binaries.

If there is an unrecognized type, it is probably a symptom of buggy
extension, use of zval after free, or shared memory corruption.
It's useful to have an alert about that.

Instead of assert(0), return the value null and trigger an error.