### PR TITLE
Fixes #188: Fix Segfault in ZTS build when locking

### DIFF
--- a/php_apc.c
+++ b/php_apc.c
@@ -210,6 +210,9 @@ static PHP_MINFO_FUNCTION(apcu)
 /* {{{ PHP_MINIT_FUNCTION(apcu) */
 static PHP_MINIT_FUNCTION(apcu)
 {
+#if defined(ZTS) && defined(COMPILE_DL_APCU)
+    ZEND_TSRMLS_CACHE_UPDATE();
+#endif
     ZEND_INIT_MODULE_GLOBALS(apcu, php_apc_init_globals, NULL);
 
     REGISTER_INI_ENTRIES();


### PR DESCRIPTION
In ZTS builds with static TSRMLS,
blocking interruptions requires TSRMLS to be initialized.

(WLOCK will block signal interruptions, then acquire a lock)

The code initialized it in RINIT (per-request), but did not initialize
it in MINIT(module init).
But module init needed to lock in order to not be interrupted while
allocating an arena in shared memory.

Fixed this by calling ZEND_TSRMLS_CACHE_UPDATE();

Other extensions do this in MINIT in both php-7.0 and php-7.1
E.g.  https://github.com/php/php-src/blob/PHP-7.0.9/ext/mbstring/mbstring.c#L1550

This worked locally when tested on php configured with `--enable-maintainer-zts --enable-debug`