### PR TITLE
 Fixes #185 : Copy key's strings from smem into request mem

### DIFF
--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -50,7 +50,9 @@ static apc_iterator_item_t* apc_iterator_item_ctor(apc_iterator_t *iterator, apc
 	}
 
 	if (APC_ITER_KEY & iterator->format) {
-		add_assoc_str(&item->value, "key", item->key);
+		/* item->key is allocated in shared memory. Return something which is emalloc()ed instead. */
+		zend_string *key_dup = zend_string_init(ZSTR_VAL(item->key), ZSTR_LEN(item->key), 0);
+		add_assoc_str(&item->value, "key", key_dup);
 	}
 
     if (APC_ITER_VALUE & iterator->format) {
@@ -442,7 +444,7 @@ PHP_METHOD(apc_iterator, key) {
     item = apc_stack_get(iterator->stack, iterator->stack_idx);
 
     if (item->key) {
-        RETURN_STR(item->key);
+        RETURN_STR(zend_string_init(ZSTR_VAL(item->key), ZSTR_LEN(item->key), 0));
     } else {
         RETURN_LONG(iterator->key_idx);
     }

--- a/tests/iterator_008.phpt
+++ b/tests/iterator_008.phpt
@@ -1,0 +1,63 @@
+--TEST--
+APC: APCUIterator should not create strings with shared memory c strings
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+--FILE--
+<?php
+
+class MyApc
+{
+    private $counterName = 'counter';
+
+    public function setCounterName($value)
+    {
+        $this->counterName = $value;
+    }
+
+    public function getCounters($name)
+    {
+        $rex = '/^' . preg_quote($name) . '\./';
+        $counters = array();
+
+        foreach (new \APCUIterator($rex, APC_ITER_KEY|APC_ITER_VALUE) as $counter) {
+            $counters[$counter['key']] = $counter['value'];
+        }
+
+        return $counters;
+    }
+
+    public function add($key, $data, $ttl = 0)
+    {
+        $ret =  apcu_store($key, $data, $ttl);
+
+        if (true !== $ret) {
+            throw new \UnexpectedValueException("apc_store call failed");
+        }
+
+        return $ret;
+    }
+}
+
+
+$myapc = new MyApc();
+
+$counterName = uniqid();
+$myapc->setCounterName($counterName);
+$myapc->add($counterName.'.test', 1);
+$results = $myapc->getCounters($counterName);
+var_export($results);
+?>
+--EXPECTF--
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+

--- a/tests/iterator_008.phpt
+++ b/tests/iterator_008.phpt
@@ -22,8 +22,8 @@ class MyApc
         $rex = '/^' . preg_quote($name) . '\./';
         $counters = array();
 
-        foreach (new \APCUIterator($rex, APC_ITER_KEY|APC_ITER_VALUE) as $counter) {
-            $counters[$counter['key']] = $counter['value'];
+        foreach (new \APCUIterator($rex, APC_ITER_KEY) as $counter) {
+            $counters[$counter['key']] = 'value';
         }
 
         return $counters;
@@ -44,20 +44,13 @@ class MyApc
 
 $myapc = new MyApc();
 
-$counterName = uniqid();
+$counterName = 'myid';
 $myapc->setCounterName($counterName);
 $myapc->add($counterName.'.test', 1);
 $results = $myapc->getCounters($counterName);
 var_export($results);
 ?>
---EXPECTF--
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-
+--EXPECT--
+array (
+  'myid.test' => 'value',
+)


### PR DESCRIPTION
Hopefully, this doesn't miss anything.
This fixes some memory leaks /invalid frees in tests/iterator_* when the tests
are run under valgrind.
    
This copies the keys from request mem into smem twice if you are doing
foreach($iterator as $key => $value), where $iterator has the flag
APC_ITER_KEY. I couldn't think of an simple way to de-duplicate, so
I didn't. (Would also have to handle possibly calling key() multiple times if
iterator was used manually)

Previously, the code was putting `zend_string`s with strings that were allocated as 

The test may be redundant.