### PR TITLE
Remove IS_CALLABLE check - zvals never have that type.

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -1613,11 +1613,6 @@ static APC_HOTSPOT zval* my_copy_zval(zval* dst, const zval* src, apc_context_t*
             return NULL;
         break;
 
-    case IS_CALLABLE:
-        /* XXX implement this */
-        assert(0);
-        break;
-
     default:
         assert(0);
     }


### PR DESCRIPTION
That type is used by the type checker, and isn't a zval type.
https://wiki.php.net/phpng-int

> IS_CALLABLE – used only for type hinting
> _IS_BOOL – used_only for type hinting