### PR TITLE
Add 7.1 to the travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
     - 7.0
+    - 7.1
     - nightly
 
 script:


### PR DESCRIPTION
7.1 was a supported release tag for a few weeks during the RCs.
7.1.0 was released on Friday.
`nightly` is similar to `7.2-dev`, so I left it in.