### PR TITLE
fix zend_alter_ini_entry() which segfault under cli.

### DIFF
--- a/php_apc.c
+++ b/php_apc.c
@@ -269,7 +269,7 @@ static PHP_MINIT_FUNCTION(apcu)
 	
     /* Disable APC in cli mode unless overridden by apc.enable_cli */
     if (!APCG(enable_cli) && !strcmp(sapi_module.name, "cli")) {
-		zend_alter_ini_entry("apc.enabled", sizeof("apc.enabled"), "0", sizeof("0")-1, PHP_INI_SYSTEM, PHP_INI_STAGE_STARTUP);
+		zend_alter_ini_entry("apc.enabled", strlen("apc.enabled"), "0", strlen("0"), PHP_INI_SYSTEM, PHP_INI_STAGE_STARTUP);
     }
 
 	/* only run initialization if APC is enabled */


### PR DESCRIPTION
when running php5-fpm already with apcu.ini:
```
extension=apcu.so
apc.enabled = 1
;apc.enable_cli = 1
```
then, execute php-cli:
```
$php -r ' var_dump("a"); '
string(1) "a"
Segmentation fault
```
however if add `apc.enable_cli = 1` to `apcu.ini`, then it works.
```
$php -r ' var_dump("a"); '
string(1) "a"
```
no Segmentation fault now.

it happened in both php5.4 and php5.6.
