### PR TITLE
Allow passing a reference to a string (in an array) to apcu_fetch

### DIFF
--- a/php_apc.c
+++ b/php_apc.c
@@ -691,6 +691,7 @@ PHP_FUNCTION(apcu_fetch) {
 			array_init(&result);
 			zend_hash_internal_pointer_reset_ex(Z_ARRVAL_P(key), &hpos);
 			while((hentry = zend_hash_get_current_data_ex(Z_ARRVAL_P(key), &hpos))) {
+			    ZVAL_DEREF(hentry);
 			    if (Z_TYPE_P(hentry) == IS_STRING) {
 					zval result_entry,
 						*iresult = &result_entry;

--- a/tests/apc_016.phpt
+++ b/tests/apc_016.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Should be able to pass references to strings to apcu_fetch
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+--FILE--
+<?php
+$array = ['foo', 'bar'];
+var_dump(apcu_store('foo', 'baz'));
+var_dump(apcu_fetch($array));
+var_dump(error_get_last());
+array_walk($array, function(&$item) {});
+var_dump($array);
+var_dump(apcu_fetch($array));
+var_dump(error_get_last());
+?>
+--EXPECT--
+bool(true)
+array(1) {
+  ["foo"]=>
+  string(3) "baz"
+}
+NULL
+array(2) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+}
+array(1) {
+  ["foo"]=>
+  string(3) "baz"
+}
+NULL


### PR DESCRIPTION
Fixes #226