### PR TITLE
APCIterator results should include cache entries considered stale due to apc.ttl

### DIFF
--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -211,10 +211,6 @@ static int apc_iterator_check_expiry(apc_cache_t* cache, apc_cache_slot_t **slot
         if((time_t) ((*slot)->ctime + (*slot)->value->ttl) < t) {
             return 0;
         }
-    } else if(cache->ttl) {
-        if((*slot)->ctime + cache->ttl < t) {
-            return 0;
-        }
     }
 
     return 1;

--- a/tests/iterator_009.phpt
+++ b/tests/iterator_009.phpt
@@ -1,0 +1,51 @@
+--TEST--
+APC: APCIterator (non-)enforcement of apc.ttl
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+<?php if (!APCU_APC_FULL_BC) { die('skip compiled without APC compatibility'); } ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.ttl=1
+apc.use_request_time=0
+--FILE--
+<?php
+apc_store("somevalue", "thedata");
+
+echo "From APCIterator before sleep: ";
+$apcIterator = new APCIterator('user', null, APC_ITER_KEY);
+foreach ($apcIterator as $key => $data) {
+  var_dump($key);
+}
+echo "\nAPCIterator->getTotalCount() before sleep: " . $apcIterator->getTotalCount() . "\n";
+
+echo "\nFrom apc_fetch before sleep: ";
+var_dump(apc_fetch("somevalue"));
+
+sleep(2);
+
+echo "\nFrom APCIterator after sleep: ";
+$apcIterator = new APCIterator('user', null, APC_ITER_KEY);
+foreach ($apcIterator as $key => $data) {
+  var_dump($key);
+}
+
+echo "\nAPCIterator->getTotalCount() after sleep: " . $apcIterator->getTotalCount() . "\n";
+
+echo "\nFrom apc_fetch after sleep: ";
+var_dump(apc_fetch("somevalue"));
+?>
+==DONE==
+--EXPECTF--
+From APCIterator before sleep: string(9) "somevalue"
+
+APCIterator->getTotalCount() before sleep: 1
+
+From apc_fetch before sleep: string(7) "thedata"
+
+From APCIterator after sleep: string(9) "somevalue"
+
+APCIterator->getTotalCount() after sleep: 1
+
+From apc_fetch after sleep: string(7) "thedata"
+==DONE==

--- a/tests/iterator_010.phpt
+++ b/tests/iterator_010.phpt
@@ -1,0 +1,49 @@
+--TEST--
+APC: APCIterator enforcement of item ttl
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+<?php if (!APCU_APC_FULL_BC) { die('skip compiled without APC compatibility'); } ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.use_request_time=0
+--FILE--
+<?php
+apc_store("somevalue", "thedata", 1);
+
+echo "From APCIterator before sleep: ";
+$apcIterator = new APCIterator('user', null, APC_ITER_KEY);
+foreach ($apcIterator as $key => $data) {
+  var_dump($key);
+}
+echo "\nAPCIterator->getTotalCount() before sleep: " . $apcIterator->getTotalCount() . "\n";
+
+echo "\nFrom apc_fetch before sleep: ";
+var_dump(apc_fetch("somevalue"));
+
+sleep(2);
+
+echo "\nFrom APCIterator after sleep: ";
+$apcIterator = new APCIterator('user', null, APC_ITER_KEY);
+foreach ($apcIterator as $key => $data) {
+  var_dump($key);
+}
+
+echo "\nAPCIterator->getTotalCount() after sleep: " . $apcIterator->getTotalCount() . "\n";
+
+echo "\nFrom apc_fetch after sleep: ";
+var_dump(apc_fetch("somevalue"));
+?>
+==DONE==
+--EXPECTF--
+From APCIterator before sleep: string(9) "somevalue"
+
+APCIterator->getTotalCount() before sleep: 1
+
+From apc_fetch before sleep: string(7) "thedata"
+
+From APCIterator after sleep: 
+APCIterator->getTotalCount() after sleep: 0
+
+From apc_fetch after sleep: bool(false)
+==DONE==


### PR DESCRIPTION
Depending on the apc.ttl setting, apc_fetch() "sees" data that APCIterator doesn't.  This seems incorrect to me.  I believe apc_fetch() is working correctly, so this PR make APCIterator work the same.