### PR TITLE
Fix #247

### DIFF
--- a/php_apc.c
+++ b/php_apc.c
@@ -698,7 +698,7 @@ PHP_FUNCTION(apcu_fetch) {
 					ZVAL_UNDEF(iresult);
 
 					if (apc_cache_fetch(apc_user_cache, Z_STR_P(hentry), t, &iresult)) {
-					    add_assoc_zval(&result, Z_STRVAL_P(hentry), &result_entry);
+					    zend_symtable_update(Z_ARRVAL(result), Z_STR_P(hentry), &result_entry);
 					}
 			    } else {
 					apc_warning("apc_fetch() expects a string or array of strings.");

--- a/tests/ghbug247.phpt
+++ b/tests/ghbug247.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH Bug #247: when a NUL char is used as key, apcu_fetch(array) truncates the key
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+--FILE--
+<?php
+apcu_store(array("a\0b" => 'foo'));
+var_dump(apcu_fetch(array("a\0b"))["a\0b"]);
+?>
+--EXPECT--
+string(3) "foo"


### PR DESCRIPTION
add_assoc_zval truncates on null bytes, instead use zend_symtable_update directly. Also a bit faster, since the string does not need to be copied.

This PR supersedes #252.