### PR TITLE
Fix crash when passing bad array to apcu_delete

### DIFF
--- a/php_apc.c
+++ b/php_apc.c
@@ -814,7 +814,7 @@ PHP_FUNCTION(apcu_delete) {
             if (Z_TYPE_P(hentry) != IS_STRING) {
                 apc_warning("apc_delete() expects a string, array of strings, or APCIterator instance.");
                 add_next_index_zval(return_value, hentry);
-                Z_ADDREF_P(hentry);
+                Z_TRY_ADDREF_P(hentry);
             } else if (apc_cache_delete(apc_user_cache, Z_STR_P(hentry)) != 1) {
                 add_next_index_zval(return_value, hentry);
                 Z_ADDREF_P(hentry);

--- a/tests/apc_099.phpt
+++ b/tests/apc_099.phpt
@@ -1,0 +1,22 @@
+--TEST--
+APCU: apcu_fetch segfault
+--SKIPIF--
+<?php
+    require_once(dirname(__FILE__) . '/skipif.inc');
+?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.file_update_protection=0
+--FILE--
+<?php
+
+apcu_store('a', 'value');
+var_export(apcu_delete(['a', 'b', 'c', 0]));
+--EXPECTF--
+Warning: apcu_delete(): apc_delete() expects a string, array of strings, or APCIterator instance. in %s on line 4
+array (
+  0 => 'b',
+  1 => 'c',
+  2 => 0,
+)


### PR DESCRIPTION
If a non refcountable type is a member of that array(e.g. null, int,
float, bool), then APCu would emit a warning, then crash.

Z_TRY_ADDREF will check if something has a reference before attempting
to increment the part of the zval that points to the reference.

This PR includes a test case that would previously cause a segfault.

Found when trying to figure out what apcu_delete does in edge cases