### PR TITLE
Remove unpool

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -101,13 +101,13 @@ apc_cache_slot_t* make_slot(apc_cache_t* cache, apc_cache_key_t *key, apc_cache_
 	apc_cache_slot_t* p = NULL;
 
 	/* allocate slot */
-	if ((p = value->pool->palloc(value->pool, sizeof(apc_cache_slot_t)))) {
+	if ((p = apc_pool_alloc(value->pool, sizeof(apc_cache_slot_t)))) {
 
 		/* copy identifier */
 		zend_string *copiedKey = apc_pstrcpy(key->str, value->pool);
 
 		if (copiedKey == NULL) {
-			value->pool->pfree(value->pool, p);
+			apc_pool_free(value->pool, p);
 			return NULL;
 		}
 
@@ -1315,7 +1315,7 @@ static APC_HOTSPOT HashTable* my_copy_hashtable(HashTable *source, apc_context_t
 	apc_pool *pool = ctxt->pool;
 
 	if (ctxt->copy == APC_COPY_IN) {
-		target = (HashTable*) pool->palloc(pool, sizeof(HashTable));
+		target = (HashTable*) apc_pool_alloc(pool, sizeof(HashTable));
 	} else {
 		ALLOC_HASHTABLE(target);
 	}
@@ -1353,7 +1353,7 @@ static APC_HOTSPOT HashTable* my_copy_hashtable(HashTable *source, apc_context_t
 		target->nNumOfElements = source->nNumOfElements;
 		target->nNextFreeElement = source->nNextFreeElement;
 		if (ctxt->copy == APC_COPY_IN) {
-			HT_SET_DATA_ADDR(target, pool->palloc(pool, HT_SIZE(target)));
+			HT_SET_DATA_ADDR(target, apc_pool_alloc(pool, HT_SIZE(target)));
 		} else
 			HT_SET_DATA_ADDR(target, emalloc(HT_SIZE(target)));
 
@@ -1385,7 +1385,7 @@ static APC_HOTSPOT HashTable* my_copy_hashtable(HashTable *source, apc_context_t
 		target->nTableMask = source->nTableMask;
 		target->nNextFreeElement = source->nNextFreeElement;
 		if (ctxt->copy == APC_COPY_IN) {
-			HT_SET_DATA_ADDR(target, pool->palloc(pool, HT_SIZE(target)));
+			HT_SET_DATA_ADDR(target, apc_pool_alloc(pool, HT_SIZE(target)));
 		} else
 			HT_SET_DATA_ADDR(target, emalloc(HT_SIZE(target)));
 
@@ -1413,7 +1413,7 @@ static APC_HOTSPOT HashTable* my_copy_hashtable(HashTable *source, apc_context_t
 	/* some kind of memory allocation failure */
 	if (target) {
 		if (ctxt->copy == APC_COPY_IN) {
-			pool->pfree(pool, target);
+			apc_pool_free(pool, target);
 		} else {
 			FREE_HASHTABLE(target);
 		}
@@ -1437,7 +1437,7 @@ static APC_HOTSPOT zend_reference* my_copy_reference(const zend_reference* src, 
 	}
 
 	if (ctxt->copy == APC_COPY_IN) {
-		dst = pool->palloc(pool, sizeof(zend_reference));
+		dst = apc_pool_alloc(pool, sizeof(zend_reference));
 	} else {
 		dst = emalloc(sizeof(zend_reference));
 	}
@@ -1598,7 +1598,7 @@ PHP_APCU_API apc_cache_entry_t* apc_cache_make_entry(apc_context_t* ctxt, apc_ca
 	apc_cache_entry_t* entry;
 	apc_pool* pool = ctxt->pool;
 
-	entry = (apc_cache_entry_t*) pool->palloc(pool, sizeof(apc_cache_entry_t));
+	entry = (apc_cache_entry_t*) apc_pool_alloc(pool, sizeof(apc_cache_entry_t));
 	if (!entry) {
 		return NULL;
 	}
@@ -1607,7 +1607,7 @@ PHP_APCU_API apc_cache_entry_t* apc_cache_make_entry(apc_context_t* ctxt, apc_ca
 	ctxt->key = key;
 
 	if (!apc_cache_store_zval(&entry->val, val, ctxt)) {
-		pool->pfree(pool, entry);
+		apc_pool_free(pool, entry);
 		return NULL;
 	}
 

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -383,9 +383,9 @@ static inline zend_bool apc_cache_insert_internal(
 
 		if ((*slot = make_slot(cache, key, value, *slot, t)) != NULL) {
 			/* set value size from pool size */
-			value->mem_size = ctxt->pool->size;
+			value->mem_size = apc_pool_size(ctxt->pool);
 
-			cache->header->mem_size += ctxt->pool->size;
+			cache->header->mem_size += value->mem_size;
 			cache->header->nentries++;
 			cache->header->ninserts++;
 		} else {

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -153,25 +153,19 @@ PHP_APCU_API void apc_cache_destroy(apc_cache_t* cache);
 PHP_APCU_API void apc_cache_clear(apc_cache_t* cache);
 
 /*
-* apc_cache_make_context initializes a context with an appropriate pool and options provided
+* apc_cache_make_copy_in/out_context initializes a context for storing values
+* into the cache or retrieving them out of the cache.
 *
-* Some of the APC API requires a context in which to operate
+* Some of the APC API requires a context in which to operate.
 *
 * The type of context required depends on the operation being performed, for example
-* an insert should happen in a shared context, a fetch should happen in a nonshared context
+* an insert should happen in a copy-in context, a fetch should happen in a copy-out context.
 */
-PHP_APCU_API zend_bool apc_cache_make_context(
-        apc_cache_t* cache, apc_context_t* context, apc_context_type context_type,
-        apc_pool_type pool_type, apc_copy_type copy_type);
+PHP_APCU_API zend_bool apc_cache_make_copy_in_context(
+		apc_cache_t* cache, apc_context_t* context, apc_pool_type pool_type);
+PHP_APCU_API zend_bool apc_cache_make_copy_out_context(
+		apc_cache_t* cache, apc_context_t* context);
 
-/*
-* apc_cache_make_context_ex is an advanced/external version of make_context
-*/
-PHP_APCU_API zend_bool apc_cache_make_context_ex(
-        apc_context_t* context, apc_serializer_t* serializer,
-        apc_malloc_t _malloc, apc_free_t _free,
-        apc_protect_t _protect, apc_unprotect_t _unprotect,
-        apc_pool_type pool_type, apc_copy_type copy_type);
 /*
 * apc_context_destroy should be called when a context is finished being used
 */

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -52,12 +52,11 @@ static apc_iterator_item_t* apc_iterator_item_ctor(apc_iterator_t *iterator, apc
 	}
 
 	if (APC_ITER_VALUE & iterator->format) {
-		apc_cache_make_context(
-			apc_user_cache, &ctxt, APC_CONTEXT_NOSHARE, APC_UNPOOL, APC_COPY_OUT);
+		apc_cache_make_copy_out_context(apc_user_cache, &ctxt);
 		ZVAL_UNDEF(&zvalue);
 		apc_cache_fetch_zval(&ctxt, &zvalue, &slot->value->val);
 		add_assoc_zval(&item->value, "value", &zvalue);
-		apc_pool_destroy(ctxt.pool);
+		apc_cache_destroy_context(&ctxt);
 	}
 
 	if (APC_ITER_NUM_HITS & iterator->format) {

--- a/apc_pool.c
+++ b/apc_pool.c
@@ -34,6 +34,27 @@
 # endif
 #endif
 
+/* {{{ structure definition: apc_pool */
+struct _apc_pool {
+	/* denotes the size and debug flags for a pool */
+	apc_pool_type   type;
+
+	/* handler functions */
+	apc_malloc_t    allocate;
+	apc_free_t      deallocate;
+
+	apc_protect_t   protect;
+	apc_unprotect_t unprotect;
+
+	/* total */
+	size_t          size;
+	/* remaining */
+	size_t          used;
+
+	/* apc_realpool and apc_unpool add more here */
+}; /* }}} */
+
+
 /*{{{ apc_realpool implementation */
 
 /* {{{ typedefs */
@@ -366,9 +387,11 @@ PHP_APCU_API apc_pool* apc_pool_create(
 
 	return &(rpool->parent);
 }
-
-
 /* }}} */
+
+PHP_APCU_API size_t apc_pool_size(apc_pool *pool) {
+	return pool->size;
+}
 
 /* }}} */
 

--- a/apc_pool.c
+++ b/apc_pool.c
@@ -71,7 +71,6 @@ struct _apc_pool {
 	size_t          used;
 
 	size_t     dsize;
-	void       *owner;
 
 	unsigned long count;
 

--- a/apc_pool.c
+++ b/apc_pool.c
@@ -384,13 +384,6 @@ PHP_APCU_API void apc_pool_init()
 }
 /* }}} */
 
-/* {{{ apc_pstrdup */
-PHP_APCU_API void* APC_ALLOC apc_pstrdup(const char* s, apc_pool* pool)
-{
-	return s != NULL ? apc_pmemcpy(s, (strlen(s) + 1), pool) : NULL;
-}
-/* }}} */
-
 /* {{{ apc_pmemcpy */
 PHP_APCU_API void* APC_ALLOC apc_pmemcpy(const void* p, size_t n, apc_pool* pool)
 {

--- a/apc_pool_api.h
+++ b/apc_pool_api.h
@@ -49,7 +49,6 @@ typedef void* (*apc_unprotect_t)(void *p); /* }}} */
 
 /* {{{ enum definition: apc_pool_type */
 typedef enum {
-	APC_UNPOOL         = 0x0,
 	APC_SMALL_POOL     = 0x1,
 	APC_MEDIUM_POOL    = 0x2,
 	APC_LARGE_POOL     = 0x3,

--- a/apc_pool_api.h
+++ b/apc_pool_api.h
@@ -41,9 +41,6 @@
 typedef struct _apc_pool apc_pool; /* }}} */
 
 /* {{{ functions */
-typedef void  (*apc_pcleanup_t)(apc_pool *pool);
-typedef void* (*apc_palloc_t)(apc_pool *pool, size_t size);
-typedef void  (*apc_pfree_t) (apc_pool *pool, void* p);
 typedef void* (*apc_protect_t)  (void *p);
 typedef void* (*apc_unprotect_t)(void *p); /* }}} */
 
@@ -69,13 +66,8 @@ struct _apc_pool {
 	apc_malloc_t    allocate;
 	apc_free_t      deallocate;
 
-	apc_palloc_t    palloc;
-	apc_pfree_t     pfree;
-
 	apc_protect_t   protect;
 	apc_unprotect_t unprotect;
-
-	apc_pcleanup_t  cleanup;
 
 	/* total */
 	size_t          size;
@@ -112,7 +104,12 @@ PHP_APCU_API apc_pool* apc_pool_create(
 /*
  apc_pool_destroy first calls apc_cleanup_t set during apc_pool_create, then apc_free_t
 */
-PHP_APCU_API void apc_pool_destroy(apc_pool* pool);
+PHP_APCU_API void apc_pool_destroy(apc_pool *pool);
+
+/* Allocate size bytes in the pool */
+PHP_APCU_API void *apc_pool_alloc(apc_pool *pool, size_t size);
+/* Free p from the pool (does nothing) */
+PHP_APCU_API void apc_pool_free(apc_pool *pool, void *p);
 
 /*
  apc_pmemcpy performs memcpy using resources provided by pool

--- a/apc_pool_api.h
+++ b/apc_pool_api.h
@@ -57,26 +57,6 @@ typedef enum {
 #endif
 } apc_pool_type; /* }}} */
 
-/* {{{ structure definition: apc_pool */
-struct _apc_pool {
-	/* denotes the size and debug flags for a pool */
-	apc_pool_type   type;
-
-	/* handler functions */
-	apc_malloc_t    allocate;
-	apc_free_t      deallocate;
-
-	apc_protect_t   protect;
-	apc_unprotect_t unprotect;
-
-	/* total */
-	size_t          size;
-	/* remaining */
-	size_t          used;
-
-	/* apc_realpool and apc_unpool add more here */
-}; /* }}} */
-
 /* {{{ enum definition: apc_copy_type */
 /* APC_COPY_IN should be used when copying into APC
    APC_COPY_OUT should be used when copying out of APC */
@@ -110,6 +90,9 @@ PHP_APCU_API void apc_pool_destroy(apc_pool *pool);
 PHP_APCU_API void *apc_pool_alloc(apc_pool *pool, size_t size);
 /* Free p from the pool (does nothing) */
 PHP_APCU_API void apc_pool_free(apc_pool *pool, void *p);
+
+/* Get allocated size of pool */
+PHP_APCU_API size_t apc_pool_size(apc_pool *pool);
 
 /*
  apc_pmemcpy performs memcpy using resources provided by pool

--- a/apc_pool_api.h
+++ b/apc_pool_api.h
@@ -94,14 +94,6 @@ typedef enum _apc_copy_type {
 	APC_COPY_OUT,
 } apc_copy_type; /* }}} */
 
-/* {{{ enum definition: apc_context_type
-	APC_CONTEXT_SHARE should be used to create contexts using shared memory
-	APC_CONTEXT_NOSHARE should be used to create contexts using standard allocators */
-typedef enum _apc_context_type {
-	APC_CONTEXT_SHARE,
-	APC_CONTEXT_NOSHARE
-} apc_context_type; /* }}} */
-
 /* {{{ struct definition: apc_context_t */
 typedef struct _apc_context_t {
 	apc_pool*          pool;            /* pool of memory for context */

--- a/apc_pool_api.h
+++ b/apc_pool_api.h
@@ -120,10 +120,5 @@ PHP_APCU_API void* apc_pmemcpy(const void* p, size_t n, apc_pool* pool);
 PHP_APCU_API zend_string* apc_pstrcpy(zend_string *str, apc_pool* pool);
 PHP_APCU_API zend_string* apc_pstrnew(unsigned char *buf, size_t buf_len, apc_pool* pool);
 
-/*
- apc_pstrdup performs strdup using resources provided by pool
-*/
-PHP_APCU_API void* apc_pstrdup(const char* s, apc_pool* pool);
-
 #endif
 


### PR DESCRIPTION
When fetching from the cache we currently allocate an unused memory pool with an "unpool" implementation. Stop doing that. Also drop the unpool, consolidate everything into one implementation, remove some no longer generality and indirection.