### PR TITLE
Improve APC iterator performance

### DIFF
--- a/apc_iterator.h
+++ b/apc_iterator.h
@@ -99,6 +99,7 @@ PHP_APCU_API void apc_iterator_obj_init(
 	zend_long list);
 PHP_APCU_API zend_class_entry* apc_iterator_get_ce(void);
 PHP_APCU_API int apc_iterator_init(int module_number);
+PHP_APCU_API int apc_iterator_shutdown(int module_number);
 
 extern int apc_iterator_delete(zval *key);
 #endif

--- a/apc_iterator.h
+++ b/apc_iterator.h
@@ -63,11 +63,9 @@ typedef struct _apc_iterator_t {
 	apc_stack_t *stack;      /* stack of entries pulled from cache */
 	int stack_idx;           /* index into the current stack */
 #ifdef ITERATOR_PCRE
+	pcre_cache_entry *pce;     /* regex filter on entry identifiers */
 # if PHP_VERSION_ID >= 70300
-	pcre2_code *re;            /* regex filter on entry identifiers */
 	pcre2_match_data *re_match_data; /* match data for regex */
-# else
-	pcre *re;                /* regex filter on entry identifiers */
 # endif
 #endif
 	zend_string *regex;

--- a/php_apc.c
+++ b/php_apc.c
@@ -293,6 +293,8 @@ static PHP_MSHUTDOWN_FUNCTION(apcu)
 #endif
 	}
 
+	apc_iterator_shutdown(module_number);
+
 	UNREGISTER_INI_ENTRIES();
 	return SUCCESS;
 } /* }}} */


### PR DESCRIPTION
 * Preallocate all the used strings, so they are not allocated anew for every single entry.
 * Allow the PCRE JIT to be used (only relevant for PHP <= 7.2, on master it was already used) for the search regex.