### PR TITLE
Misc

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -615,8 +615,8 @@ PHP_APCU_API zend_bool apc_cache_preload(apc_cache_t* cache, const char *path)
 #endif
 } /* }}} */
 
-/* {{{ apc_cache_release */
-PHP_APCU_API void apc_cache_release(apc_cache_t* cache, apc_cache_entry_t* entry)
+/* {{{ apc_cache_entry_release */
+PHP_APCU_API void apc_cache_entry_release(apc_cache_t *cache, apc_cache_entry_t *entry)
 {
 	ATOMIC_DEC(cache, entry->ref_count);
 }
@@ -867,9 +867,9 @@ PHP_APCU_API zend_bool apc_cache_fetch(apc_cache_t* cache, zend_string *key, tim
 	}
 
 	php_apc_try {
-		retval = apc_cache_fetch_zval(cache, entry, *dst);
+		retval = apc_cache_entry_fetch_zval(cache, entry, *dst);
 	} php_apc_finally {
-		apc_cache_release(cache, entry);
+		apc_cache_entry_release(cache, entry);
 	} php_apc_end_try();
 
 	return retval;
@@ -1409,8 +1409,8 @@ PHP_APCU_API zval* apc_cache_store_zval(zval* dst, const zval* src, apc_context_
 }
 /* }}} */
 
-/* {{{ apc_cache_fetch_zval */
-PHP_APCU_API zend_bool apc_cache_fetch_zval(
+/* {{{ apc_cache_entry_fetch_zval */
+PHP_APCU_API zend_bool apc_cache_entry_fetch_zval(
 		apc_cache_t *cache, apc_cache_entry_t *entry, zval *dst)
 {
 	apc_context_t ctxt = {0, };
@@ -1718,8 +1718,8 @@ PHP_APCU_API void apc_cache_entry(apc_cache_t *cache, zval *key, zend_fcall_info
 					cache, Z_STR_P(key), return_value, (uint32_t) ttl, 1);
 			}
 		} else {
-			apc_cache_fetch_zval(cache, entry, return_value);
-			apc_cache_release(cache, entry);
+			apc_cache_entry_fetch_zval(cache, entry, return_value);
+			apc_cache_entry_release(cache, entry);
 		}
 	} php_apc_finally {
 		apc_cache_entry_try_end();

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -146,25 +146,6 @@ PHP_APCU_API void apc_cache_destroy(apc_cache_t* cache);
 PHP_APCU_API void apc_cache_clear(apc_cache_t* cache);
 
 /*
-* apc_cache_make_copy_in/out_context initializes a context for storing values
-* into the cache or retrieving them out of the cache.
-*
-* Some of the APC API requires a context in which to operate.
-*
-* The type of context required depends on the operation being performed, for example
-* an insert should happen in a copy-in context, a fetch should happen in a copy-out context.
-*/
-PHP_APCU_API zend_bool apc_cache_make_copy_in_context(
-		apc_cache_t* cache, apc_context_t* context, apc_pool_type pool_type);
-PHP_APCU_API zend_bool apc_cache_make_copy_out_context(
-		apc_cache_t* cache, apc_context_t* context);
-
-/*
-* apc_context_destroy should be called when a context is finished being used
-*/
-PHP_APCU_API zend_bool apc_cache_destroy_context(apc_context_t* context);
-
-/*
  * apc_cache_insert adds an entry to the cache.
  * Returns true if the entry was successfully inserted, false otherwise.
  * If false is returned, the caller must free the entry pool.
@@ -202,23 +183,19 @@ PHP_APCU_API zend_bool apc_cache_fetch(apc_cache_t* cache, zend_string *key, tim
 
 /*
  * apc_cache_exists searches for a cache entry by its hashed identifier,
- * and returns a pointer to the entry if found, NULL otherwise.  This is a
- * quick non-locking version of apc_cache_find that does not modify the
- * shared memory segment in any way.
- *
+ * and returns whether the entry exists.
  */
-PHP_APCU_API apc_cache_entry_t* apc_cache_exists(apc_cache_t* cache, zend_string *key, time_t t);
+PHP_APCU_API zend_bool apc_cache_exists(apc_cache_t* cache, zend_string *key, time_t t);
 
 /*
  * apc_cache_delete and apc_cache_delete finds an entry in the cache and deletes it.
  */
 PHP_APCU_API zend_bool apc_cache_delete(apc_cache_t* cache, zend_string *key);
 
-/* apc_cach_fetch_zval takes a zval in the cache and reconstructs a runtime
- * zval from it.
- *
+/* apc_cache_fetch_zval copies a cache entry value to be usable at runtime.
  */
-PHP_APCU_API zval* apc_cache_fetch_zval(apc_context_t* ctxt, zval* dst, const zval* src);
+PHP_APCU_API zend_bool apc_cache_fetch_zval(
+		apc_cache_t *cache, apc_cache_entry_t *entry, zval *dst);
 
 /*
  * apc_cache_release decrements the reference count associated with a cache

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -194,11 +194,11 @@ PHP_APCU_API zend_bool apc_cache_delete(apc_cache_t* cache, zend_string *key);
 
 /* apc_cache_fetch_zval copies a cache entry value to be usable at runtime.
  */
-PHP_APCU_API zend_bool apc_cache_fetch_zval(
+PHP_APCU_API zend_bool apc_cache_entry_fetch_zval(
 		apc_cache_t *cache, apc_cache_entry_t *entry, zval *dst);
 
 /*
- * apc_cache_release decrements the reference count associated with a cache
+ * apc_cache_entry_release decrements the reference count associated with a cache
  * entry. Calling apc_cache_find automatically increments the reference count,
  * and this function must be called post-execution to return the count to its
  * original value. Failing to do so will prevent the entry from being
@@ -206,7 +206,7 @@ PHP_APCU_API zend_bool apc_cache_fetch_zval(
  *
  * entry is the cache entry whose ref count you want to decrement.
  */
-PHP_APCU_API void apc_cache_release(apc_cache_t* cache, apc_cache_entry_t* entry);
+PHP_APCU_API void apc_cache_entry_release(apc_cache_t *cache, apc_cache_entry_t *entry);
 
 /*
  * apc_cache_make_entry creates an apc_cache_entry_t given a zval, context and ttl

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -290,17 +290,6 @@ PHP_APCU_API void apc_cache_serializer(apc_cache_t* cache, const char* name);
 PHP_APCU_API void apc_cache_default_expunge(apc_cache_t* cache, size_t size);
 
 /*
-* The remaining functions are used during the APCu implementation of expunge
-*/
-
-/*
-* apc_cache_real_expunge: trashes the whole cache
-*
-* Note: it is assumed you have a write lock on the header when you enter real expunge
-*/
-PHP_APCU_API void apc_cache_real_expunge(apc_cache_t* cache);
-
-/*
 * apc_cache_entry: generate and create or fetch an entry
 *
 * @see https://github.com/krakjoe/apcu/issues/142

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -301,13 +301,6 @@ PHP_APCU_API void apc_cache_default_expunge(apc_cache_t* cache, size_t size);
 PHP_APCU_API void apc_cache_real_expunge(apc_cache_t* cache);
 
 /*
-* apc_cache_gc: runs garbage collection on cache
-*
-* Note: it is assumed you have a write lock on the header when you enter gc
-*/
-PHP_APCU_API void apc_cache_gc(apc_cache_t* cache);
-
-/*
 * apc_cache_entry: generate and create or fetch an entry
 *
 * @see https://github.com/krakjoe/apcu/issues/142

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -38,8 +38,9 @@ typedef pid_t apc_cache_owner_t;
 
 typedef struct apc_cache_slam_key_t apc_cache_slam_key_t;
 struct apc_cache_slam_key_t {
-	zend_string *str;        /* the key for this cached entry */
-	time_t mtime;            /* the mtime of this cached entry */
+	zend_ulong hash;         /* hash of the key */
+	size_t len;              /* length of the key */
+	time_t mtime;            /* creation time of this key */
 	apc_cache_owner_t owner; /* the context that created this key */
 };
 

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -146,18 +146,6 @@ PHP_APCU_API void apc_cache_destroy(apc_cache_t* cache);
 PHP_APCU_API void apc_cache_clear(apc_cache_t* cache);
 
 /*
- * apc_cache_insert adds an entry to the cache.
- * Returns true if the entry was successfully inserted, false otherwise.
- * If false is returned, the caller must free the entry pool.
- *
- * entry is a cache entry returned by apc_cache_make_entry.
- *
- * an easier API exists in the form of apc_cache_store
- */
-PHP_APCU_API zend_bool apc_cache_insert(
-        apc_cache_t *cache, apc_cache_entry_t *entry, zend_bool exclusive);
-
-/*
  * apc_cache_store creates key, entry and context in which to make an insertion of val into the specified cache
  */
 PHP_APCU_API zend_bool apc_cache_store(
@@ -207,12 +195,6 @@ PHP_APCU_API zend_bool apc_cache_entry_fetch_zval(
  * entry is the cache entry whose ref count you want to decrement.
  */
 PHP_APCU_API void apc_cache_entry_release(apc_cache_t *cache, apc_cache_entry_t *entry);
-
-/*
- * apc_cache_make_entry creates an apc_cache_entry_t given a zval, context and ttl
- */
-PHP_APCU_API apc_cache_entry_t *apc_cache_make_entry(
-        apc_context_t *ctxt, zend_string *key, const zval *val, const int32_t ttl, time_t t);
 
 /*
  fetches information about the cache provided for userland status functions

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -308,16 +308,6 @@ PHP_APCU_API void apc_cache_real_expunge(apc_cache_t* cache);
 PHP_APCU_API void apc_cache_gc(apc_cache_t* cache);
 
 /*
-* apc_cache_remove_entry: removes entry
-*
-* if no references remain, the entry is free'd immediately
-* if there are references remaining, the entry is trashed
-*
-* Note: it is assumed you have a write lock on the header when you remove entries
-*/
-PHP_APCU_API void apc_cache_remove_entry(apc_cache_t *cache, apc_cache_entry_t **entry);
-
-/*
 * apc_cache_entry: generate and create or fetch an entry
 *
 * @see https://github.com/krakjoe/apcu/issues/142

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -74,7 +74,7 @@ static apc_iterator_item_t* apc_iterator_item_ctor(
 
 	if (APC_ITER_VALUE & iterator->format) {
 		ZVAL_UNDEF(&zv);
-		apc_cache_fetch_zval(apc_user_cache, entry, &zv);
+		apc_cache_entry_fetch_zval(apc_user_cache, entry, &zv);
 		zend_hash_add_new(ht, apc_str_value, &zv);
 	}
 

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -55,7 +55,6 @@ static apc_iterator_item_t* apc_iterator_item_ctor(
 		apc_iterator_t *iterator, apc_cache_entry_t *entry) {
 	zval zv;
 	HashTable *ht;
-	apc_context_t ctxt = {0, };
 	apc_iterator_item_t *item = ecalloc(1, sizeof(apc_iterator_item_t));
 
 	array_init(&item->value);
@@ -74,11 +73,9 @@ static apc_iterator_item_t* apc_iterator_item_ctor(
 	}
 
 	if (APC_ITER_VALUE & iterator->format) {
-		apc_cache_make_copy_out_context(apc_user_cache, &ctxt);
 		ZVAL_UNDEF(&zv);
-		apc_cache_fetch_zval(&ctxt, &zv, &entry->val);
+		apc_cache_fetch_zval(apc_user_cache, entry, &zv);
 		zend_hash_add_new(ht, apc_str_value, &zv);
-		apc_cache_destroy_context(&ctxt);
 	}
 
 	if (APC_ITER_NUM_HITS & iterator->format) {

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -61,7 +61,7 @@ static apc_iterator_item_t* apc_iterator_item_ctor(
 	array_init(&item->value);
 	ht = Z_ARRVAL(item->value);
 
-	item->key = zend_string_dup(entry->key.str, 0);
+	item->key = zend_string_dup(entry->key, 0);
 
 	if (APC_ITER_TYPE & iterator->format) {
 		ZVAL_STR_COPY(&zv, apc_str_user);
@@ -86,7 +86,7 @@ static apc_iterator_item_t* apc_iterator_item_ctor(
 		zend_hash_add_new(ht, apc_str_num_hits, &zv);
 	}
 	if (APC_ITER_MTIME & iterator->format) {
-		ZVAL_LONG(&zv, entry->key.mtime);
+		ZVAL_LONG(&zv, entry->mtime);
 		zend_hash_add_new(ht, apc_str_mtime, &zv);
 	}
 	if (APC_ITER_CTIME & iterator->format) {
@@ -196,19 +196,19 @@ static int apc_iterator_search_match(apc_iterator_t *iterator, apc_cache_entry_t
 # if PHP_VERSION_ID >= 70300
 		rval = pcre2_match(
 			php_pcre_pce_re(iterator->pce),
-			(PCRE2_SPTR) ZSTR_VAL(entry->key.str), ZSTR_LEN(entry->key.str),
+			(PCRE2_SPTR) ZSTR_VAL(entry->key), ZSTR_LEN(entry->key),
 			0, 0, iterator->re_match_data, php_pcre_mctx()) >= 0;
 # else
 		rval = pcre_exec(
 			iterator->pce->re, iterator->pce->extra,
-			ZSTR_VAL(entry->key.str), ZSTR_LEN(entry->key.str),
+			ZSTR_VAL(entry->key), ZSTR_LEN(entry->key),
 			0, 0, NULL, 0) >= 0;
 # endif
 	}
 #endif
 
 	if (iterator->search_hash) {
-		rval = zend_hash_exists(iterator->search_hash, entry->key.str);
+		rval = zend_hash_exists(iterator->search_hash, entry->key);
 	}
 
 	return rval;

--- a/apc_sma.c
+++ b/apc_sma.c
@@ -453,28 +453,7 @@ PHP_APCU_API void* apc_sma_api_malloc(apc_sma_t* sma, zend_ulong n)
 
 PHP_APCU_API void* apc_sma_api_realloc(apc_sma_t* sma, void* p, zend_ulong n) {
 	apc_sma_api_free(sma, p);
-	return apc_sma_api_malloc(
-		sma, n);
-}
-
-PHP_APCU_API char* apc_sma_api_strdup(apc_sma_t* sma, const char* s) {
-	void* q;
-	int len;
-
-	if(!s) {
-		return NULL;
-	}
-
-	len = strlen(s)+1;
-	q = apc_sma_api_malloc(
-		sma, len);
-
-	if(!q) {
-		return NULL;
-	}
-
-	memcpy(q, s, len);
-	return q;
+	return apc_sma_api_malloc(sma, n);
 }
 
 PHP_APCU_API void apc_sma_api_free(apc_sma_t* sma, void* p) {

--- a/apc_sma_api.h
+++ b/apc_sma_api.h
@@ -64,7 +64,6 @@ typedef void (*apc_sma_cleanup_f) ();
 typedef void* (*apc_sma_malloc_f) (zend_ulong size);
 typedef void* (*apc_sma_malloc_ex_f) (zend_ulong size, zend_ulong fragment, zend_ulong *allocated);
 typedef void* (*apc_sma_realloc_f) (void* p, zend_ulong size);
-typedef char* (*apc_sma_strdup_f) (const char* str);
 typedef void (*apc_sma_free_f) (void *p);
 typedef void* (*apc_sma_protect_f) (void* p);
 typedef void* (*apc_sma_unprotect_f) (void* p);
@@ -85,7 +84,6 @@ typedef struct _apc_sma_t {
 	apc_sma_malloc_f smalloc;                    /* malloc */
 	apc_sma_malloc_ex_f malloc_ex;               /* malloc_ex */
 	apc_sma_realloc_f realloc;                   /* realloc */
-	apc_sma_strdup_f strdup;                     /* strdup */
 	apc_sma_free_f sfree;                        /* free */
 	apc_sma_protect_f protect;                   /* protect */
 	apc_sma_unprotect_f unprotect;               /* unprotect */
@@ -137,11 +135,6 @@ PHP_APCU_API void* apc_sma_api_malloc_ex(
 * apc_sma_api_realloc will reallocate p using a new block from sma (freeing the original p)
 */
 PHP_APCU_API void* apc_sma_api_realloc(apc_sma_t* sma, void* p, zend_ulong size);
-
-/*
-* apc_sma_api_strdup will duplicate the given string into a block from sma
-*/
-PHP_APCU_API char* apc_sma_api_strdup(apc_sma_t* sma, const char* s);
 
 /*
 * apc_sma_api_free will free p (which should be a pointer to a block allocated from sma)
@@ -211,7 +204,6 @@ typedef union { void* p; int i; long l; double d; void (*f)(void); } apc_word_t;
 	PHP_APCU_API void* apc_sma_api_func(name, malloc)(zend_ulong size); \
 	PHP_APCU_API void* apc_sma_api_func(name, malloc_ex)(zend_ulong size, zend_ulong fragment, zend_ulong* allocated); \
 	PHP_APCU_API void* apc_sma_api_func(name, realloc)(void* p, zend_ulong size); \
-	PHP_APCU_API char* apc_sma_api_func(name, strdup)(const char* s); \
 	PHP_APCU_API void apc_sma_api_func(name, free)(void* p); \
 	PHP_APCU_API void* apc_sma_api_func(name, protect)(void* p); \
 	PHP_APCU_API void* apc_sma_api_func(name, unprotect)(void* p); \
@@ -229,7 +221,6 @@ typedef union { void* p; int i; long l; double d; void (*f)(void); } apc_word_t;
 		&apc_sma_api_func(name, malloc), \
 		&apc_sma_api_func(name, malloc_ex), \
 		&apc_sma_api_func(name, realloc), \
-		&apc_sma_api_func(name, strdup), \
 		&apc_sma_api_func(name, free), \
 		&apc_sma_api_func(name, protect), \
 		&apc_sma_api_func(name, unprotect), \
@@ -249,8 +240,6 @@ typedef union { void* p; int i; long l; double d; void (*f)(void); } apc_word_t;
 		{ return apc_sma_api_malloc_ex(apc_sma_api_ptr(name), size, fragment, allocated); } \
 	PHP_APCU_API void* apc_sma_api_func(name, realloc)(void* p, zend_ulong size) \
 		{ return apc_sma_api_realloc(apc_sma_api_ptr(name), p, size); } \
-	PHP_APCU_API char* apc_sma_api_func(name, strdup)(const char* s) \
-		{ return apc_sma_api_strdup(apc_sma_api_ptr(name), s); } \
 	PHP_APCU_API void  apc_sma_api_func(name, free)(void* p) \
 		{ apc_sma_api_free(apc_sma_api_ptr(name), p); } \
 	PHP_APCU_API void* apc_sma_api_func(name, protect)(void* p) \


### PR DESCRIPTION
Remove many operations from the public API. Introduce a naming convention where `apc_cache_rlocked` and `apc_cache_wlocked` prefixes mean that the cache is expected to be rlocked or wlocked respectively.

Between the renaming and code movement, there are some functional changes:
 * The owner is no longer stored in the cache entry, as it's only needed for slam defense.
 * Slam defense now explicitly stores the hash and length of the last inserted key. Storing a zend_string reference doesn't guarantee that the string will still exist at the time the slam defense check is performed. Combined with the the fact that getting the hash is a potentially writing operation, this might actually lead to memory corruption.
 * Slam defense is now performed prior to creating the copy-in context. This means that no SMA allocations will be performed if slam defense triggers.
 * The refcount decrement on the cache entry is now performed in a php_apc_finally block, as the unserialization could lead to a bailout.