### PR TITLE
Don't pass PHP_TEST_ARGS through to test child processes

### DIFF
--- a/tests/server_test.inc
+++ b/tests/server_test.inc
@@ -23,19 +23,17 @@ function server_start_one($host, $port, $code = 'echo "Hello world";', $php_opts
 		2 => STDERR,
 	);
 
-	$php_args = getenv('TEST_PHP_ARGS');
-	if (empty($php_args)) {
-		$ext = (substr(PHP_OS, 0, 3) == 'WIN') ? 'php_apcu.dll' : 'apcu.so';
-		if (substr(PHP_OS, 0, 3) == 'WIN') {
-			$part0 = 8 == PHP_INT_SIZE ? "x64" : "";
-			$part1 = ZEND_DEBUG_BUILD ? "Debug" : "Release";
-			$part1 = PHP_ZTS ? ($part1 . "_TS") : $part1;
-			$php_args = "-d extension_dir=$doc_root/../$part0/$part1";
-		} else {
-			$php_args = "-d extension_dir=$doc_root/../modules";
-		}
-		$php_args = "$php_args -d extension=$ext";
+	$ext = (substr(PHP_OS, 0, 3) == 'WIN') ? 'php_apcu.dll' : 'apcu.so';
+	if (substr(PHP_OS, 0, 3) == 'WIN') {
+		$part0 = 8 == PHP_INT_SIZE ? "x64" : "";
+		$part1 = ZEND_DEBUG_BUILD ? "Debug" : "Release";
+		$part1 = PHP_ZTS ? ($part1 . "_TS") : $part1;
+		$php_args = "-d extension_dir=$doc_root/../$part0/$part1";
+	} else {
+		$php_args = "-d extension_dir=$doc_root/../modules";
 	}
+	$php_args = "$php_args -d extension=$ext";
+
 	if ($php_opts) {
 		$php_args = "$php_args -d " . implode(' -d ', $php_opts);;
 	}


### PR DESCRIPTION
`TEST_PHP_ARGS` is used to pass args to run-tests.php, they should not be passed directly to PHP itself. CI doesn't use this so it can be removed.

Also update bc submodule to latest upstream version to ensure tests pass when `git clone --recursive` is used.