### PR TITLE
Improve mmap error handling

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -286,11 +286,11 @@ PHP_APCU_API apc_cache_t* apc_cache_create(apc_sma_t* sma, apc_serializer_t* ser
 	cache->shmaddr = apc_sma_malloc(sma, cache_size);
 
 	if (!cache->shmaddr) {
-		zend_error_noreturn(E_CORE_ERROR, "Unable to allocate shared memory for cache structures. Perhaps your shared memory size isn't large enough?");
+		zend_error_noreturn(E_CORE_ERROR, "Unable to allocate %zu bytes of shared memory for cache structures. Either apc.shm_size is too small or apc.entries_hint too large", cache_size);
 		return NULL;
 	}
 
-	/* zero shm */
+	/* zero cache header and hash slots */
 	memset(cache->shmaddr, 0, cache_size);
 
 	/* set default header */
@@ -316,9 +316,6 @@ PHP_APCU_API apc_cache_t* apc_cache_create(apc_sma_t* sma, apc_serializer_t* ser
 
 	/* header lock */
 	CREATE_LOCK(&cache->header->lock);
-
-	/* zero slots */
-	memset(cache->slots, 0, sizeof(apc_cache_entry_t *) * nslots);
 
 	return cache;
 } /* }}} */

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -285,8 +285,8 @@ PHP_APCU_API apc_cache_t* apc_cache_create(apc_sma_t* sma, apc_serializer_t* ser
 	/* allocate shm */
 	cache->shmaddr = apc_sma_malloc(sma, cache_size);
 
-	if(!cache->shmaddr) {
-		apc_error("Unable to allocate shared memory for cache structures.  (Perhaps your shared memory size isn't large enough?). ");
+	if (!cache->shmaddr) {
+		zend_error_noreturn(E_CORE_ERROR, "Unable to allocate shared memory for cache structures. Perhaps your shared memory size isn't large enough?");
 		return NULL;
 	}
 

--- a/apc_mmap.c
+++ b/apc_mmap.c
@@ -75,7 +75,7 @@ apc_segment_t apc_mmap(char *file_mask, size_t size)
 	} else if(!strcmp(file_mask,"/dev/zero")) {
 		fd = open("/dev/zero", O_RDWR, S_IRUSR | S_IWUSR);
 		if(fd == -1) {
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: open on /dev/zero failed:");
+			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: open on /dev/zero failed");
 		}
 #ifdef APC_MEMPROTECT
 		remap = 0; /* cannot remap */
@@ -92,16 +92,16 @@ apc_segment_t apc_mmap(char *file_mask, size_t size)
 		 * path you want here.
 		 */
 		if(!mktemp(file_mask)) {
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: mktemp on %s failed:", file_mask);
+			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: mktemp on %s failed", file_mask);
 		}
 		fd = shm_open(file_mask, O_CREAT|O_RDWR, S_IRUSR|S_IWUSR);
 		if(fd == -1) {
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: shm_open on %s failed:", file_mask);
+			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: shm_open on %s failed", file_mask);
 		}
 		if (ftruncate(fd, size) < 0) {
 			close(fd);
 			shm_unlink(file_mask);
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: ftruncate failed:");
+			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: ftruncate failed");
 		}
 		shm_unlink(file_mask);
 	} else {
@@ -110,12 +110,12 @@ apc_segment_t apc_mmap(char *file_mask, size_t size)
 		 */
 		fd = mkstemp(file_mask);
 		if(fd == -1) {
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: mkstemp on %s failed:", file_mask);
+			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: mkstemp on %s failed", file_mask);
 		}
 		if (ftruncate(fd, size) < 0) {
 			close(fd);
 			unlink(file_mask);
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: ftruncate failed:");
+			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: ftruncate failed");
 		}
 		unlink(file_mask);
 	}
@@ -131,11 +131,11 @@ apc_segment_t apc_mmap(char *file_mask, size_t size)
 	}
 #endif
 
-	if((long)segment.shmaddr == -1) {
-		zend_error_noreturn(E_CORE_ERROR, "apc_mmap: mmap failed:");
+	if ((long)segment.shmaddr == -1) {
+		zend_error_noreturn(E_CORE_ERROR, "apc_mmap: Failed to mmap %zu bytes. Is your apc.shm_size too large?", size);
 	}
 
-	if(fd != -1) close(fd);
+	if (fd != -1) close(fd);
 
 	return segment;
 }
@@ -143,12 +143,12 @@ apc_segment_t apc_mmap(char *file_mask, size_t size)
 void apc_unmap(apc_segment_t *segment)
 {
 	if (munmap(segment->shmaddr, segment->size) < 0) {
-		apc_warning("apc_unmap: munmap failed:");
+		apc_warning("apc_unmap: munmap failed");
 	}
 
 #ifdef APC_MEMPROTECT
 	if (segment->roaddr && munmap(segment->roaddr, segment->size) < 0) {
-		apc_warning("apc_unmap: munmap failed:");
+		apc_warning("apc_unmap: munmap failed");
 	}
 #endif
 

--- a/apc_shm.c
+++ b/apc_shm.c
@@ -53,7 +53,7 @@ int apc_shm_create(int proj, size_t size)
 
 	oflag = IPC_CREAT | SHM_R | SHM_A;
 	if ((shmid = shmget(key, size, oflag)) < 0) {
-		apc_error("apc_shm_create: shmget(%d, %zd, %d) failed: %s. It is possible that the chosen SHM segment size is higher than the operation system allows. Linux has usually a default limit of 32MB per segment.", key, size, oflag, strerror(errno));
+		zend_error_noreturn(E_CORE_ERROR, "apc_shm_create: shmget(%d, %zd, %d) failed: %s. It is possible that the chosen SHM segment size is higher than the operation system allows. Linux has usually a default limit of 32MB per segment.", key, size, oflag, strerror(errno));
 	}
 
 	return shmid;
@@ -70,7 +70,7 @@ apc_segment_t apc_shm_attach(int shmid, size_t size)
 	apc_segment_t segment; /* shm segment */
 
 	if ((zend_long)(segment.shmaddr = shmat(shmid, 0, 0)) == -1) {
-		apc_error("apc_shm_attach: shmat failed:");
+		zend_error_noreturn(E_CORE_ERROR, "apc_shm_attach: shmat failed:");
 	}
 
 #ifdef APC_MEMPROTECT
@@ -94,12 +94,12 @@ apc_segment_t apc_shm_attach(int shmid, size_t size)
 void apc_shm_detach(apc_segment_t* segment)
 {
 	if (shmdt(segment->shmaddr) < 0) {
-		apc_error("apc_shm_detach: shmdt failed:");
+		apc_warning("apc_shm_detach: shmdt failed:");
 	}
 
 #ifdef APC_MEMPROTECT
 	if (segment->roaddr && shmdt(segment->roaddr) < 0) {
-		apc_error("apc_shm_detach: shmdt failed:");
+		apc_warning("apc_shm_detach: shmdt failed:");
 	}
 #endif
 }

--- a/tests/not_enough_shm.phpt
+++ b/tests/not_enough_shm.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Error if cache structures cannot be allocated in SHM
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.shm_size=1M
+apc.entries_hint=1000000
+--FILE--
+Irrelevant
+--EXPECTF--
+%A
+Fatal error: Unable to allocate %d bytes of shared memory for cache structures. Either apc.shm_size is too small or apc.entries_hint too large in Unknown on line 0


### PR DESCRIPTION
* Use `E_CORE_ERROR` to make sure startup is aborted -- otherwise we would segfault lateron.
* Print a better error message, including the size of the allocation.