### PR TITLE
Use interned strings in more places

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -997,23 +997,32 @@ static void apc_cache_init_entry(
 }
 /* }}} */
 
+static inline void array_add_long(zval *array, zend_string *key, zend_long lval) {
+	zval zv;
+	ZVAL_LONG(&zv, lval);
+	zend_hash_add_new(Z_ARRVAL_P(array), key, &zv);
+}
+
 /* {{{ apc_cache_link_info */
 static zval apc_cache_link_info(apc_cache_t *cache, apc_cache_entry_t *p)
 {
-	zval link;
-
+	zval link, zv;
 	array_init(&link);
 
-	add_assoc_str(&link, "info", zend_string_dup(p->key, 0));
-	add_assoc_long(&link, "ttl", p->ttl);
+	ZVAL_STR(&zv, zend_string_dup(p->key, 0));
+	zend_hash_add_new(Z_ARRVAL(link), apc_str_info, &zv);
 
-	add_assoc_double(&link, "num_hits", (double)p->nhits);
-	add_assoc_long(&link, "mtime", p->mtime);
-	add_assoc_long(&link, "creation_time", p->ctime);
-	add_assoc_long(&link, "deletion_time", p->dtime);
-	add_assoc_long(&link, "access_time", p->atime);
-	add_assoc_long(&link, "ref_count", p->ref_count);
-	add_assoc_long(&link, "mem_size", p->mem_size);
+	array_add_long(&link, apc_str_ttl, p->ttl);
+
+	ZVAL_DOUBLE(&zv, (double) p->nhits);
+	zend_hash_add_new(Z_ARRVAL(link), apc_str_num_hits, &zv);
+
+	array_add_long(&link, apc_str_mtime, p->mtime);
+	array_add_long(&link, apc_str_creation_time, p->ctime);
+	array_add_long(&link, apc_str_deletion_time, p->dtime);
+	array_add_long(&link, apc_str_access_time, p->atime);
+	array_add_long(&link, apc_str_ref_count, p->ref_count);
+	array_add_long(&link, apc_str_mem_size, p->mem_size);
 
 	return link;
 }
@@ -1089,12 +1098,6 @@ PHP_APCU_API zend_bool apc_cache_info(zval *info, apc_cache_t *cache, zend_bool 
 	return 1;
 }
 /* }}} */
-
-static inline void array_add_long(zval *array, zend_string *key, zend_long lval) {
-	zval zv;
-	ZVAL_LONG(&zv, lval);
-	zend_hash_add_new(Z_ARRVAL_P(array), key, &zv);
-}
 
 /*
  fetches information about the key provided

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -31,6 +31,7 @@
 #include "apc_cache.h"
 #include "apc_sma.h"
 #include "apc_globals.h"
+#include "apc_strings.h"
 #include "php_scandir.h"
 #include "SAPI.h"
 #include "TSRM.h"
@@ -1089,6 +1090,12 @@ PHP_APCU_API zend_bool apc_cache_info(zval *info, apc_cache_t *cache, zend_bool 
 }
 /* }}} */
 
+static inline void array_add_long(zval *array, zend_string *key, zend_long lval) {
+	zval zv;
+	ZVAL_LONG(&zv, lval);
+	zend_hash_add_new(Z_ARRVAL_P(array), key, &zv);
+}
+
 /*
  fetches information about the key provided
 */
@@ -1112,15 +1119,13 @@ PHP_APCU_API void apc_cache_stat(apc_cache_t *cache, zend_string *key, zval *sta
 			/* check for a matching key by has and identifier */
 			if (apc_entry_key_equals(entry, key, h)) {
 				array_init(stat);
-
-				add_assoc_long(stat, "hits",  entry->nhits);
-				add_assoc_long(stat, "access_time", entry->atime);
-				add_assoc_long(stat, "mtime", entry->mtime);
-				add_assoc_long(stat, "creation_time", entry->ctime);
-				add_assoc_long(stat, "deletion_time", entry->dtime);
-				add_assoc_long(stat, "ttl", entry->ttl);
-				add_assoc_long(stat, "refs", entry->ref_count);
-
+				array_add_long(stat, apc_str_hits, entry->nhits);
+				array_add_long(stat, apc_str_access_time, entry->atime);
+				array_add_long(stat, apc_str_mtime, entry->mtime);
+				array_add_long(stat, apc_str_creation_time, entry->ctime);
+				array_add_long(stat, apc_str_deletion_time, entry->dtime);
+				array_add_long(stat, apc_str_ttl, entry->ttl);
+				array_add_long(stat, apc_str_refs, entry->ref_count);
 				break;
 			}
 

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -1003,6 +1003,12 @@ static inline void array_add_long(zval *array, zend_string *key, zend_long lval)
 	zend_hash_add_new(Z_ARRVAL_P(array), key, &zv);
 }
 
+static inline void array_add_double(zval *array, zend_string *key, double dval) {
+	zval zv;
+	ZVAL_DOUBLE(&zv, dval);
+	zend_hash_add_new(Z_ARRVAL_P(array), key, &zv);
+}
+
 /* {{{ apc_cache_link_info */
 static zval apc_cache_link_info(apc_cache_t *cache, apc_cache_entry_t *p)
 {
@@ -1013,10 +1019,7 @@ static zval apc_cache_link_info(apc_cache_t *cache, apc_cache_entry_t *p)
 	zend_hash_add_new(Z_ARRVAL(link), apc_str_info, &zv);
 
 	array_add_long(&link, apc_str_ttl, p->ttl);
-
-	ZVAL_DOUBLE(&zv, (double) p->nhits);
-	zend_hash_add_new(Z_ARRVAL(link), apc_str_num_hits, &zv);
-
+	array_add_double(&link, apc_str_num_hits, (double) p->nhits);
 	array_add_long(&link, apc_str_mtime, p->mtime);
 	array_add_long(&link, apc_str_creation_time, p->ctime);
 	array_add_long(&link, apc_str_deletion_time, p->dtime);
@@ -1046,14 +1049,14 @@ PHP_APCU_API zend_bool apc_cache_info(zval *info, apc_cache_t *cache, zend_bool 
 	php_apc_try {
 		array_init(info);
 		add_assoc_long(info, "num_slots", cache->nslots);
-		add_assoc_long(info, "ttl", cache->ttl);
-		add_assoc_double(info, "num_hits", (double)cache->header->nhits);
-		add_assoc_double(info, "num_misses", (double)cache->header->nmisses);
-		add_assoc_double(info, "num_inserts", (double)cache->header->ninserts);
+		array_add_long(info, apc_str_ttl, cache->ttl);
+		array_add_double(info, apc_str_num_hits, (double) cache->header->nhits);
+		add_assoc_double(info, "num_misses", (double) cache->header->nmisses);
+		add_assoc_double(info, "num_inserts", (double) cache->header->ninserts);
 		add_assoc_long(info,   "num_entries", cache->header->nentries);
-		add_assoc_double(info, "expunges", (double)cache->header->nexpunges);
+		add_assoc_double(info, "expunges", (double) cache->header->nexpunges);
 		add_assoc_long(info, "start_time", cache->header->stime);
-		add_assoc_double(info, "mem_size", (double)cache->header->mem_size);
+		array_add_double(info, apc_str_mem_size, (double) cache->header->mem_size);
 
 #if APC_MMAP
 		add_assoc_stringl(info, "memory_type", "mmap", sizeof("mmap")-1);

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -20,31 +20,14 @@
 #include "php_apc.h"
 #include "apc_iterator.h"
 #include "apc_cache.h"
+#include "apc_strings.h"
 
 #include "ext/standard/md5.h"
 #include "SAPI.h"
 #include "zend_interfaces.h"
 
-#define APC_STRINGS \
-	X(user) \
-	X(type) \
-	X(key) \
-	X(value) \
-	X(num_hits) \
-	X(mtime) \
-	X(creation_time) \
-	X(deletion_time) \
-	X(access_time) \
-	X(ref_count) \
-	X(mem_size) \
-	X(ttl)
-
 static zend_class_entry *apc_iterator_ce;
 zend_object_handlers apc_iterator_object_handlers;
-
-#define X(str) static zend_string *apc_str_ ## str;
-	APC_STRINGS
-#undef X
 
 zend_class_entry* apc_iterator_get_ce(void) {
 	return apc_iterator_ce;
@@ -628,21 +611,11 @@ int apc_iterator_init(int module_number) {
 	apc_iterator_object_handlers.free_obj = apc_iterator_free;
 	apc_iterator_object_handlers.offset = XtOffsetOf(apc_iterator_t, obj);
 
-#define X(str) \
-	apc_str_ ## str = zend_new_interned_string( \
-		zend_string_init(#str, sizeof(#str) - 1, 1));
-	APC_STRINGS
-#undef X
-
 	return SUCCESS;
 }
 /* }}} */
 
 int apc_iterator_shutdown(int module_number) {
-#define X(str) zend_string_release(apc_str_ ## str);
-	APC_STRINGS
-#undef X
-
 	return SUCCESS;
 }
 

--- a/apc_strings.h
+++ b/apc_strings.h
@@ -20,18 +20,20 @@
 #define APC_STRINGS_H
 
 #define APC_STRINGS \
-	X(user) \
-	X(type) \
-	X(key) \
-	X(value) \
-	X(num_hits) \
-	X(mtime) \
+	X(access_time) \
 	X(creation_time) \
 	X(deletion_time) \
-	X(access_time) \
-	X(ref_count) \
+	X(hits) \
+	X(key) \
 	X(mem_size) \
-	X(ttl)
+	X(mtime) \
+	X(num_hits) \
+	X(ref_count) \
+	X(refs) \
+	X(ttl) \
+	X(type) \
+	X(user) \
+	X(value) \
 
 #define X(str) extern zend_string *apc_str_ ## str;
 	APC_STRINGS

--- a/apc_strings.h
+++ b/apc_strings.h
@@ -24,6 +24,7 @@
 	X(creation_time) \
 	X(deletion_time) \
 	X(hits) \
+	X(info) \
 	X(key) \
 	X(mem_size) \
 	X(mtime) \

--- a/apc_strings.h
+++ b/apc_strings.h
@@ -1,0 +1,40 @@
+/*
+  +----------------------------------------------------------------------+
+  | APC                                                                  |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2006-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Nikita Popov <nikic@php.net>                                |
+  +----------------------------------------------------------------------+
+ */
+
+#ifndef APC_STRINGS_H
+#define APC_STRINGS_H
+
+#define APC_STRINGS \
+	X(user) \
+	X(type) \
+	X(key) \
+	X(value) \
+	X(num_hits) \
+	X(mtime) \
+	X(creation_time) \
+	X(deletion_time) \
+	X(access_time) \
+	X(ref_count) \
+	X(mem_size) \
+	X(ttl)
+
+#define X(str) extern zend_string *apc_str_ ## str;
+	APC_STRINGS
+#undef X
+
+#endif

--- a/php_apc.c
+++ b/php_apc.c
@@ -34,6 +34,7 @@
 #include "apc_iterator.h"
 #include "apc_sma.h"
 #include "apc_lock.h"
+#include "apc_strings.h"
 #include "php_globals.h"
 #include "php_ini.h"
 #include "ext/standard/info.h"
@@ -77,6 +78,10 @@ apc_cache_t* apc_user_cache = NULL;
 
 /* External APC SMA */
 apc_sma_t apc_sma;
+
+#define X(str) zend_string *apc_str_ ## str;
+	APC_STRINGS
+#undef X
 
 /* Global init functions */
 static void php_apc_init_globals(zend_apcu_globals* apcu_globals)
@@ -214,6 +219,12 @@ static PHP_MINIT_FUNCTION(apcu)
 
 	REGISTER_INI_ENTRIES();
 
+#define X(str) \
+	apc_str_ ## str = zend_new_interned_string( \
+		zend_string_init(#str, sizeof(#str) - 1, 1));
+	APC_STRINGS
+#undef X
+
 	/* locks initialized regardless of settings */
 	apc_lock_init();
 
@@ -273,6 +284,10 @@ static PHP_MINIT_FUNCTION(apcu)
 /* {{{ PHP_MSHUTDOWN_FUNCTION(apcu) */
 static PHP_MSHUTDOWN_FUNCTION(apcu)
 {
+#define X(str) zend_string_release(apc_str_ ## str);
+	APC_STRINGS
+#undef X
+
 	/* locks shutdown regardless of settings */
 	apc_lock_cleanup();
 


### PR DESCRIPTION
In particular make apcu_key_info and the relevant parts of apcu_cache_info use interned string keys.