### PR TITLE
Make apcu_cas require only read-lock

### DIFF
--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -94,6 +94,9 @@ typedef struct _apc_cache_t {
 /* {{{ typedef: apc_cache_updater_t */
 typedef zend_bool (*apc_cache_updater_t)(apc_cache_t*, apc_cache_entry_t*, void* data); /* }}} */
 
+/* {{{ typedef: apc_cache_atomic_updater_t */
+typedef zend_bool (*apc_cache_atomic_updater_t)(apc_cache_t*, zend_long*, void* data); /* }}} */
+
 /*
  * apc_cache_create creates the shared memory cache.
  *
@@ -147,10 +150,19 @@ PHP_APCU_API zend_bool apc_cache_store(
         apc_cache_t* cache, zend_string *key, const zval *val,
         const int32_t ttl, const zend_bool exclusive);
 /*
-* apc_cache_update updates an entry in place, this is used for inc/dec/cas
-*/
+ * apc_cache_update updates an entry in place. The updater function must not bailout.
+ * The update is performed under write-lock and doesn't have to be atomic.
+ */
 PHP_APCU_API zend_bool apc_cache_update(
 		apc_cache_t *cache, zend_string *key, apc_cache_updater_t updater, void *data,
+		zend_bool insert_if_not_found, zend_long ttl);
+
+/*
+ * apc_cache_atomic_update_long updates an integer entry in place. The updater function must
+ * perform the update atomically, as the update is performed under read-lock.
+ */
+PHP_APCU_API zend_bool apc_cache_atomic_update_long(
+		apc_cache_t *cache, zend_string *key, apc_cache_atomic_updater_t updater, void *data,
 		zend_bool insert_if_not_found, zend_long ttl);
 
 /*

--- a/apc_lock_api.h
+++ b/apc_lock_api.h
@@ -103,13 +103,16 @@ PHP_APCU_API void apc_lock_destroy(apc_lock_t *lock); /* }}} */
 # ifdef _WIN64
 #  define ATOMIC_INC(a) InterlockedIncrement64(&a)
 #  define ATOMIC_DEC(a) InterlockedDecrement64(&a)
+#  define ATOMIC_CAS(a, old, new) (InterlockedCompareExchange64(&a, new, old) == old)
 # else
 #  define ATOMIC_INC(a) InterlockedIncrement(&a)
 #  define ATOMIC_DEC(a) InterlockedDecrement(&a)
+#  define ATOMIC_CAS(a, old, new) (InterlockedCompareExchange(&a, new, old) == old)
 # endif
 #else
 # define ATOMIC_INC(a) __sync_add_and_fetch(&a, 1)
 # define ATOMIC_DEC(a) __sync_sub_and_fetch(&a, 1)
+# define ATOMIC_CAS(a, old, new) __sync_bool_compare_and_swap(&a, old, new)
 #endif
 
 #endif

--- a/php_apc.c
+++ b/php_apc.c
@@ -604,19 +604,11 @@ PHP_FUNCTION(apcu_dec) {
 /* }}} */
 
 /* {{{ php_cas_updater */
-static zend_bool php_cas_updater(apc_cache_t* cache, apc_cache_entry_t* entry, void* data) {
-	zend_long* vals = ((zend_long*)data);
+static zend_bool php_cas_updater(apc_cache_t *cache, zend_long *entry, void *data) {
+	zend_long *vals = (zend_long *) data;
 	zend_long old = vals[0];
 	zend_long new = vals[1];
-
-	if (Z_TYPE(entry->val) == IS_LONG) {
-		if (Z_LVAL(entry->val) == old) {
-			Z_LVAL(entry->val) = new;
-			return 1;
-		}
-	}
-
-	return 0;
+	return ATOMIC_CAS(*entry, old, new);
 }
 /* }}} */
 
@@ -630,7 +622,12 @@ PHP_FUNCTION(apcu_cas) {
 		return;
 	}
 
-	RETURN_BOOL(php_apc_update(key, php_cas_updater, &vals, 0, 0));
+	if (APCG(serializer_name)) {
+		/* Avoid race conditions between MINIT of apc and serializer exts like igbinary */
+		apc_cache_serializer(apc_user_cache, APCG(serializer_name));
+	}
+
+	RETURN_BOOL(apc_cache_atomic_update_long(apc_user_cache, key, php_cas_updater, &vals, 0, 0));
 }
 /* }}} */
 


### PR DESCRIPTION
This changes the implementation of apcu_cas to only acquire a read-lock on the cache (to prevent a concurrent write), and perform the update itself using atomic compare-and-swap.

I've not updated inc/dec here, because I'm unsure on how to handle the overflow behavior. Right now apcu_inc/dec will overflow into double (at which point it will stop being incremented). If we switch this to atomic we'd get a wraparound instead.

I'm not sure how worthwhile this change is overall.