### PR TITLE
Clarify/fix cleanup operations

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -649,20 +649,17 @@ PHP_APCU_API void apc_cache_entry_release(apc_cache_t *cache, apc_cache_entry_t 
 }
 /* }}} */
 
-/* {{{ apc_cache_destroy */
-PHP_APCU_API void apc_cache_destroy(apc_cache_t* cache)
+/* {{{ apc_cache_detach */
+PHP_APCU_API void apc_cache_detach(apc_cache_t *cache)
 {
+	/* Important: This function should not clean up anything that's in shared memory,
+	 * only detach our process-local use of it. In particular locks cannot be destroyed
+	 * here. */
+
 	if (!cache) {
 		return;
 	}
 
-	/* destroy lock */
-	DESTROY_LOCK(&cache->header->lock);
-
-	/* XXX this is definitely a leak, but freeing this causes all the apache
-		children to freeze. It might be because the segment is shared between
-		several processes. To figure out is how to free this safely. */
-	/*apc_sma_free(cache->shmaddr);*/
 	free(cache);
 }
 /* }}} */

--- a/apc_cache_api.h
+++ b/apc_cache_api.h
@@ -125,11 +125,11 @@ PHP_APCU_API apc_cache_t* apc_cache_create(
 PHP_APCU_API zend_bool apc_cache_preload(apc_cache_t* cache, const char* path);
 
 /*
- * apc_cache_destroy releases any OS resources associated with a cache object.
- * Under apache, this function can be safely called by the child processes
- * when they exit.
+ * apc_cache_detach detaches from the shared memory cache and cleans up
+ * local allocations. Under apache, this function can be safely called by
+ * the child processes when they exit.
  */
-PHP_APCU_API void apc_cache_destroy(apc_cache_t* cache);
+PHP_APCU_API void apc_cache_detach(apc_cache_t* cache);
 
 /*
  * apc_cache_clear empties a cache. This can safely be called at any time.

--- a/apc_lock.c
+++ b/apc_lock.c
@@ -114,7 +114,7 @@ PHP_APCU_API zend_bool apc_lock_runlock(apc_lock_t *lock) {
 }
 
 PHP_APCU_API void apc_lock_destroy(apc_lock_t *lock) {
-	/* nothing */
+	pthread_rwlock_destroy(lock);
 }
 
 #elif defined(APC_LOCK_RECURSIVE)
@@ -173,7 +173,7 @@ PHP_APCU_API zend_bool apc_lock_runlock(apc_lock_t *lock) {
 }
 
 PHP_APCU_API void apc_lock_destroy(apc_lock_t *lock) {
-	/* nothing */
+	pthread_mutex_destroy(lock);
 }
 
 #elif defined(APC_SPIN_LOCK)

--- a/apc_signal.c
+++ b/apc_signal.c
@@ -52,12 +52,12 @@ static void apc_clear_cache(int signo, siginfo_t *siginfo, void *context);
 extern apc_cache_t* apc_user_cache;
 
 /* {{{ apc_core_unmap
- *  Coredump signal handler, unmaps shm and calls previously installed handlers
+ *  Coredump signal handler, detached from shm and calls previously installed handlers
  */
 static void apc_core_unmap(int signo, siginfo_t *siginfo, void *context)
 {
 	if (apc_user_cache) {
-		apc_sma_cleanup(apc_user_cache->sma);
+		apc_sma_detach(apc_user_cache->sma);
 	}
 	apc_rehandle_signal(signo, siginfo, context);
 

--- a/apc_sma.c
+++ b/apc_sma.c
@@ -465,11 +465,6 @@ PHP_APCU_API void* apc_sma_malloc(apc_sma_t* sma, zend_ulong n)
 	return apc_sma_malloc_ex(sma, n, MINBLOCKSIZE, &allocated);
 }
 
-PHP_APCU_API void* apc_sma_realloc(apc_sma_t* sma, void* p, zend_ulong n) {
-	apc_sma_free(sma, p);
-	return apc_sma_malloc(sma, n);
-}
-
 PHP_APCU_API void apc_sma_free(apc_sma_t* sma, void* p) {
 	uint i;
 	size_t offset;

--- a/apc_sma_api.h
+++ b/apc_sma_api.h
@@ -87,9 +87,9 @@ PHP_APCU_API void apc_sma_init(
 		int32_t num, zend_ulong size, char *mask);
 
 /*
-* apc_sma_api_cleanup will free the sma allocator
-*/
-PHP_APCU_API void apc_sma_cleanup(apc_sma_t* sma);
+ * apc_sma_detach will detach from shared memory and cleanup local allocations.
+ */
+PHP_APCU_API void apc_sma_detach(apc_sma_t* sma);
 
 /*
 * apc_smap_api_malloc will allocate a block from the sma of the given size

--- a/apc_sma_api.h
+++ b/apc_sma_api.h
@@ -103,11 +103,6 @@ PHP_APCU_API void* apc_sma_malloc_ex(
 		apc_sma_t* sma, zend_ulong size, zend_ulong fragment, zend_ulong* allocated);
 
 /*
-* apc_sma_api_realloc will reallocate p using a new block from sma (freeing the original p)
-*/
-PHP_APCU_API void* apc_sma_realloc(apc_sma_t* sma, void* p, zend_ulong size);
-
-/*
 * apc_sma_api_free will free p (which should be a pointer to a block allocated from sma)
 */
 PHP_APCU_API void apc_sma_free(apc_sma_t* sma, void* p);

--- a/php_apc.c
+++ b/php_apc.c
@@ -297,11 +297,9 @@ static PHP_MSHUTDOWN_FUNCTION(apcu)
 	/* only shut down if APC is enabled */
 	if (APCG(enabled)) {
 		if (APCG(initialized)) {
-
-			/* destroy cache pointer */
-			apc_cache_destroy(apc_user_cache);
-			/* cleanup shared memory */
-			apc_sma_cleanup(&apc_sma);
+			/* Detach cache and shared memory allocator from shared memory. */
+			apc_cache_detach(apc_user_cache);
+			apc_sma_detach(&apc_sma);
 
 			APCG(initialized) = 0;
 		}


### PR DESCRIPTION
Rename destroy/cleanup to detach to clarify that this is only about detaching local instances, not about cleaning up anything inside SHM. In particular remove calls to lock destruction.

Ref #338.