### PR TITLE
Some fixes to persistence

### DIFF
--- a/php_apc.c
+++ b/php_apc.c
@@ -472,6 +472,7 @@ static void apc_store_helper(INTERNAL_FUNCTION_PARAMETERS, const zend_bool exclu
 		array_init(return_value);
 
 		ZEND_HASH_FOREACH_KEY_VAL(hash, hkey_idx, hkey, hentry) {
+			ZVAL_DEREF(hentry);
 			if (hkey) {
 				if (!apc_cache_store(apc_user_cache, hkey, hentry, (uint32_t) ttl, exclusive)) {
 					zend_hash_add_new(Z_ARRVAL_P(return_value), hkey, &fail_zv);

--- a/tests/apc_store_reference.phpt
+++ b/tests/apc_store_reference.phpt
@@ -1,0 +1,27 @@
+--TEST--
+The outermost value should always be a value, not a reference
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.serializer=default
+--FILE--
+<?php
+
+/* The output is different for the php serializer, because it does not replicate the
+ * cycle involving the top-level value. Instead the cycle is placed one level lower.
+ * I believe this is a bug in the php serializer. */
+
+$value = [&$value];
+apcu_store(["key" => &$value]);
+$result = apcu_fetch("key");
+var_dump($result);
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(1) {
+    [0]=>
+    *RECURSION*
+  }
+}


### PR DESCRIPTION
Make sure top-level values are not references (this can cause issues if the value is returned from apcu_fetch, which violated PHP's reference return semantics). Furthermore use GC_ARRAY to mark returned arrays as GC collectible.