### PR TITLE
Try to reduce SMA fragmentation

### DIFF
--- a/tests/sma001.phpt
+++ b/tests/sma001.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test SMA behavior #1
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.shm_size=16M
+--FILE--
+<?php
+
+// Make sure that a sequence of alternating small and large
+// allocations does not result in catastrophic fragmentation
+
+$len = 1024 * 1024;
+for ($i = 0; $i < 100; $i++) {
+    apcu_delete("key");
+    $result = apcu_store("key", str_repeat("x", $len));
+    if ($result === false) {
+        echo "Failed $i.\n";
+    }
+
+    // Force a small allocation
+    apcu_store("dummy" . $i, null);
+
+    // Increase $len slightly
+    $len += 100;
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
Instead of picking the first fitting block, check if there is
a smaller block that still fits. We only look at a limited, small
number of additional blocks. This is an approximation of best-fit
allocation.

This is intended to reduce fragmentation, in particular for the
case where a large block was recently freed (and is on top of the
free list) and a small allocation is performed.