### PR TITLE
Autodetect igbinary and fix entries output on apc.php

### DIFF
--- a/apc.php
+++ b/apc.php
@@ -1045,7 +1045,12 @@ EOB;
 				echo '</tr>';
 				if ($sh == $MYREQUEST["SH"]) {
 					echo '<tr>';
-					echo '<td colspan="7"><pre>'.htmlentities(print_r(apcu_fetch($entry['info']), 1)).'</pre></td>';
+					$raw_entry = apcu_fetch($entry['info']);
+                                        if(extension_loaded('igbinary')) {
+                                                $entry = @igbinary_unserialize($raw_entry);
+                                        }
+                                        $entry = $entry?:unserialize($raw_entry);
+					echo '<td colspan="7"><pre>'.htmlentities(print_r($entry, 1)).'</pre></td>';
 					echo '</tr>';
 				}
 				$i++;


### PR DESCRIPTION
Hi,

When using igbinary serialization, the apc.php dashboard doesn't show the cache entries when going into the "user cache entries" menu.
Also, the previous code was apparently missing the unserialize call so all we got was the serialized string (for entries serialized with php) or empty strings (when using igbinary) which wasn't really useful for viewing/debugging cache entries.

This is a quick fix that detects if igbinary is loaded and if the cache entry can be correctly unserialized with it, otherwise just use regular unserialize.

I've tested this locally with php7.3 with projects that are using both igbinary and php serialization and I can now correctly see all cache entries independently of serialization displayed through print_r, which is what I believe the original code was meant to do.

Note that I only tested with projects with a low number of keys. As this introduces a couple of extra checks I'm not really sure of the impact when using many keys but I doubt its critical as most people that use this is probably just for developing and debugging(?)

Anyway, it's just a minor fix that I've been doing on my own local installs for a while now so I though a PR to fix this may be useful for some people using this script.
Cheers.