### PR TITLE
use mkstemp instead of mktemp

### DIFF
--- a/apc_lock.c
+++ b/apc_lock.c
@@ -281,8 +281,8 @@ PHP_APCU_API void apc_lock_cleanup() {
 
 PHP_APCU_API zend_bool apc_lock_create(apc_lock_t *lock) {
 	char lock_path[] = "/tmp/.apc.XXXXXX";
-	mktemp(lock_path);
-	*lock = open(lock_path, O_RDWR|O_CREAT, 0666);
+
+	*lock = mkstemp(lock_path);
 	if (*lock > 0) {
 		unlink(lock_path);
 		return 1;

--- a/apc_mmap.c
+++ b/apc_mmap.c
@@ -80,30 +80,6 @@ apc_segment_t apc_mmap(char *file_mask, size_t size)
 #ifdef APC_MEMPROTECT
 		remap = 0; /* cannot remap */
 #endif
-	} else if(strstr(file_mask,".shm")) {
-		/*
-		 * If the filemask contains .shm we try to do a POSIX-compliant shared memory
-		 * backed mmap which should avoid synchs on some platforms.  At least on
-		 * FreeBSD this implies MAP_NOSYNC and on Linux it is equivalent of mmap'ing
-		 * a file in a mounted shmfs.  For this to work on Linux you need to make sure
-		 * you actually have shmfs mounted.  Also on Linux, make sure the file_mask you
-		 * pass in has a leading / and no other /'s.  eg.  /apc.shm.XXXXXX
-		 * On FreeBSD these are mapped onto the regular filesystem so you can put whatever
-		 * path you want here.
-		 */
-		if(!mktemp(file_mask)) {
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: mktemp on %s failed", file_mask);
-		}
-		fd = shm_open(file_mask, O_CREAT|O_RDWR, S_IRUSR|S_IWUSR);
-		if(fd == -1) {
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: shm_open on %s failed", file_mask);
-		}
-		if (ftruncate(fd, size) < 0) {
-			close(fd);
-			shm_unlink(file_mask);
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: ftruncate failed");
-		}
-		shm_unlink(file_mask);
 	} else {
 		/*
 		 * Otherwise we do a normal filesystem mmap


### PR DESCRIPTION
@nikic can you please have a look at mktemp usage which is strongly discouraged

I was able to fix 1 case, but unable to test it... can't find the bulid option to use this part of code... :(

Main issue is with apc_mmap.c, as only the name is needed and don't need to be a real path, can't find a "simple" fix for this one...
