### PR TITLE
Removed deprecated uint and ulong types to conform to php master (8.0)

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -577,7 +577,7 @@ static int apc_load_data(apc_cache_t* cache, const char *data_file)
 {
 	char *p;
 	char key[MAXPATHLEN] = {0,};
-	unsigned int key_len;
+	size_t key_len;
 	zval data;
 
 	p = strrchr(data_file, DEFAULT_SLASH);
@@ -1095,7 +1095,7 @@ PHP_APCU_API zend_bool apc_cache_info(zval *info, apc_cache_t *cache, zend_bool 
 					j++;
 				}
 				if (j != 0) {
-					add_index_long(&slots, (ulong)i, j);
+					add_index_long(&slots, (unsigned long)i, j);
 				}
 			}
 

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -1095,7 +1095,7 @@ PHP_APCU_API zend_bool apc_cache_info(zval *info, apc_cache_t *cache, zend_bool 
 					j++;
 				}
 				if (j != 0) {
-					add_index_long(&slots, (unsigned long)i, j);
+					add_index_long(&slots, (zend_ulong)i, j);
 				}
 			}
 

--- a/apc_sma.c
+++ b/apc_sma.c
@@ -289,7 +289,7 @@ static APC_HOTSPOT size_t sma_deallocate(void* shmaddr, size_t offset)
 
 /* {{{ APC SMA API */
 PHP_APCU_API void apc_sma_init(apc_sma_t* sma, void** data, apc_sma_expunge_f expunge, int32_t num, size_t size, char *mask) {
-	uint i;
+	int32_t i;
 
 	if (sma->initialized) {
 		return;
@@ -382,7 +382,7 @@ PHP_APCU_API void apc_sma_detach(apc_sma_t* sma) {
 	/* Important: This function should not clean up anything that's in shared memory,
 	 * only detach our process-local use of it. In particular locks cannot be destroyed
 	 * here. */
-	uint i;
+	int32_t i;
 
 	assert(sma->initialized);
 	sma->initialized = 0;
@@ -401,7 +401,7 @@ PHP_APCU_API void apc_sma_detach(apc_sma_t* sma) {
 PHP_APCU_API void *apc_sma_malloc_ex(apc_sma_t *sma, size_t n, size_t *allocated) {
 	size_t fragment = MINBLOCKSIZE;
 	size_t off;
-	uint i;
+	int32_t i;
 	zend_bool nuked = 0;
 	int32_t last = sma->last;
 
@@ -464,7 +464,7 @@ PHP_APCU_API void* apc_sma_malloc(apc_sma_t* sma, size_t n)
 }
 
 PHP_APCU_API void apc_sma_free(apc_sma_t* sma, void* p) {
-	uint i;
+	int32_t i;
 	size_t offset;
 
 	if (p == NULL) {
@@ -552,7 +552,7 @@ PHP_APCU_API void* apc_sma_unprotect(apc_sma_t* sma, void *p) { return p; }
 PHP_APCU_API apc_sma_info_t *apc_sma_info(apc_sma_t* sma, zend_bool limited) {
 	apc_sma_info_t *info;
 	apc_sma_link_t **link;
-	uint i;
+	int32_t i;
 	char *shmaddr;
 	block_t *prv;
 
@@ -618,7 +618,7 @@ PHP_APCU_API void apc_sma_free_info(apc_sma_t *sma, apc_sma_info_t *info) {
 
 PHP_APCU_API size_t apc_sma_get_avail_mem(apc_sma_t* sma) {
 	size_t avail_mem = 0;
-	uint i;
+	int32_t i;
 
 	for (i = 0; i < sma->num; i++) {
 		sma_header_t* header = SMA_HDR(sma, i);
@@ -628,7 +628,7 @@ PHP_APCU_API size_t apc_sma_get_avail_mem(apc_sma_t* sma) {
 }
 
 PHP_APCU_API zend_bool apc_sma_get_avail_size(apc_sma_t* sma, size_t size) {
-	uint i;
+	int32_t i;
 
 	for (i = 0; i < sma->num; i++) {
 		sma_header_t* header = SMA_HDR(sma, i);


### PR DESCRIPTION
The apcu extension does not compile on the current php master due to the removal of uint and ulong types.
See [the revelant commit](https://github.com/php/php-src/commit/bebcdcc74573b015c22238dbc9b2698c88b7a601).
And fixed another size_t/unsigned int conversion warning.

![Untitled](https://user-images.githubusercontent.com/21277377/58179054-ac15c000-7ca7-11e9-9b75-04547b1b5b1f.png)
