### PR TITLE
Implement apcu_inc/dec using atomic operations

### DIFF
--- a/apc_lock_api.h
+++ b/apc_lock_api.h
@@ -98,15 +98,18 @@ PHP_APCU_API void apc_lock_destroy(apc_lock_t *lock); /* }}} */
 # ifdef _WIN64
 #  define ATOMIC_INC(a) InterlockedIncrement64(&a)
 #  define ATOMIC_DEC(a) InterlockedDecrement64(&a)
+#  define ATOMIC_ADD(a, b) (InterlockedExchangeAdd64(&a, b) + b)
 #  define ATOMIC_CAS(a, old, new) (InterlockedCompareExchange64(&a, new, old) == old)
 # else
 #  define ATOMIC_INC(a) InterlockedIncrement(&a)
 #  define ATOMIC_DEC(a) InterlockedDecrement(&a)
+#  define ATOMIC_ADD(a, b) (InterlockedExchangeAdd(&a, b) + b)
 #  define ATOMIC_CAS(a, old, new) (InterlockedCompareExchange(&a, new, old) == old)
 # endif
 #else
 # define ATOMIC_INC(a) __sync_add_and_fetch(&a, 1)
 # define ATOMIC_DEC(a) __sync_sub_and_fetch(&a, 1)
+# define ATOMIC_ADD(a, b) __sync_add_and_fetch(&a, b)
 # define ATOMIC_CAS(a, old, new) __sync_bool_compare_and_swap(&a, old, new)
 #endif
 

--- a/tests/apc_012.phpt
+++ b/tests/apc_012.phpt
@@ -1,5 +1,5 @@
 --TEST--
-APC: integer overflow consistency
+APC: Atomic inc + dec wrap around on overflow
 --SKIPIF--
 <?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
 --INI--
@@ -7,30 +7,29 @@ apc.enabled=1
 apc.enable_cli=1
 --FILE--
 <?php
-$key="testkey";
-$i=PHP_INT_MAX;
-apcu_store($key, $i);
-var_dump($j=apcu_fetch($key));
-var_dump($i==$j);
+$key = "testkey";
 
-apcu_inc($key, 1);
-$i++;
-var_dump($j=apcu_fetch($key));
-var_dump($i==$j);
+apcu_store($key, PHP_INT_MAX);
+var_dump($i = apcu_inc($key, 1));
+var_dump($j = apcu_fetch($key));
+var_dump($i == $j);
+var_dump($j == PHP_INT_MIN);
 
-$i=PHP_INT_MIN;
-apcu_store($key, $i);
-apcu_dec($key, 1);
-$i--;
-var_dump($j=apcu_fetch($key));
-var_dump($i==$j);
+apcu_store($key, PHP_INT_MIN);
+var_dump($i = apcu_dec($key, 1));
+var_dump($j = apcu_fetch($key));
+var_dump($i == $j);
+var_dump($j == PHP_INT_MAX);
+
 ?>
 ===DONE===
 --EXPECTF--
-int(%d)
+int(%i)
+int(%i)
 bool(true)
-float(%s)
 bool(true)
-float(%s)
+int(%i)
+int(%i)
+bool(true)
 bool(true)
 ===DONE===


### PR DESCRIPTION
This also changes apcu_inc/dec to wrap around on overflow, instead of saturating to a float value.

Fixes #343.