### PR TITLE
Set apc.use_request_time=0 by default

### DIFF
--- a/php_apc.c
+++ b/php_apc.c
@@ -93,7 +93,7 @@ static void php_apc_init_globals(zend_apcu_globals* apcu_globals)
 	apcu_globals->smart = 0;
 	apcu_globals->preload_path = NULL;
 	apcu_globals->coredump_unmap = 0;
-	apcu_globals->use_request_time = 1;
+	apcu_globals->use_request_time = 0;
 	apcu_globals->serializer_name = NULL;
 	apcu_globals->recursion = 0;
 }
@@ -151,7 +151,7 @@ STD_PHP_INI_BOOLEAN("apc.enable_cli",   "0",    PHP_INI_SYSTEM, OnUpdateBool,   
 STD_PHP_INI_BOOLEAN("apc.slam_defense", "0",    PHP_INI_SYSTEM, OnUpdateBool,              slam_defense,     zend_apcu_globals, apcu_globals)
 STD_PHP_INI_ENTRY("apc.preload_path", (char*)NULL,              PHP_INI_SYSTEM, OnUpdateString,       preload_path,  zend_apcu_globals, apcu_globals)
 STD_PHP_INI_BOOLEAN("apc.coredump_unmap", "0", PHP_INI_SYSTEM, OnUpdateBool, coredump_unmap, zend_apcu_globals, apcu_globals)
-STD_PHP_INI_BOOLEAN("apc.use_request_time", "1", PHP_INI_ALL, OnUpdateBool, use_request_time,  zend_apcu_globals, apcu_globals)
+STD_PHP_INI_BOOLEAN("apc.use_request_time", "0", PHP_INI_ALL, OnUpdateBool, use_request_time,  zend_apcu_globals, apcu_globals)
 STD_PHP_INI_ENTRY("apc.serializer", "php", PHP_INI_SYSTEM, OnUpdateStringUnempty, serializer_name, zend_apcu_globals, apcu_globals)
 PHP_INI_END()
 


### PR DESCRIPTION
The default used to be 1, which meant that the effective TTL upon storing and fetching keys was backdated to the beginning of the web request.

This means values are not stored as long as users might expect, and might also appear valid longer than expected.

For example, during POST request that 2s and stores a value in APCu with a TTL of 500ms, the value effectively can't be re-used by other requests as 0.5 - 2 <= 0.

Closes https://github.com/krakjoe/apcu/issues/391.