### PR TITLE
Improve and update AppVeyor CI integration

### DIFF
--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,0 +1,28 @@
+$ts_part = ''
+if ('0' -eq $env:TS) { $ts_part = '-nts' }
+$bname = 'php-devel-pack-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
+if (-not (Test-Path c:\build-cache\$bname)) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+        if (-not (Test-Path c:\build-cache\$bname)) {
+                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+        }
+}
+$dname0 = 'php-' + $env:PHP_VER + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
+$dname1 = 'php-' + $env:PHP_VER + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
+if (-not (Test-Path c:\build-cache\$dname1)) {
+        7z x c:\build-cache\$bname -oc:\build-cache
+        move c:\build-cache\$dname0 c:\build-cache\$dname1
+}
+cd c:\projects\apcu
+$env:PATH = 'c:\build-cache\' + $dname1 + ';' + $env:PATH
+#echo "@echo off" | Out-File -Encoding "ASCII" task.bat
+#echo "" | Out-File -Encoding "ASCII" -Append task.bat
+echo "" | Out-File -Encoding "ASCII" task.bat
+echo "call phpize 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
+echo "call configure --enable-apcu --enable-debug-pack 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
+echo "nmake /nologo 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
+echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
+$here = (Get-Item -Path "." -Verbose).FullName
+$runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
+$task = $here + '\task.bat'
+& $runner -t $task

--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $ts_part = ''
 if ($env:TS -eq '0') {
     $ts_part += '-nts'
@@ -13,7 +15,9 @@ $dname0 = "php-$env:PHP_VER-devel-$env:VC-$env:ARCH"
 $dname1 = "php-$env:PHP_VER$ts_part-devel-$env:VC-$env:ARCH"
 if (-not (Test-Path "c:\build-cache\$dname1")) {
     Expand-Archive "c:\build-cache\$bname" "c:\build-cache"
-    Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
+    if ($dname0 -ne $dname1) {
+        Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
+    }
 }
 
 Set-Location 'c:\projects\apcu'
@@ -25,3 +29,6 @@ Add-Content $task "call configure --enable-apcu --enable-debug-pack 2>&1"
 Add-Content $task "nmake /nologo 2>&1"
 Add-Content $task "exit %errorlevel%"
 & "c:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task
+if (-not $?) {
+    throw "build failed with errorlevel $LastExitCode"
+}

--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,28 +1,27 @@
 $ts_part = ''
-if ('0' -eq $env:TS) { $ts_part = '-nts' }
-$bname = 'php-devel-pack-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
-if (-not (Test-Path c:\build-cache\$bname)) {
-        Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-        if (-not (Test-Path c:\build-cache\$bname)) {
-                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-        }
+if ($env:TS -eq '0') {
+    $ts_part += '-nts'
 }
-$dname0 = 'php-' + $env:PHP_VER + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
-$dname1 = 'php-' + $env:PHP_VER + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
-if (-not (Test-Path c:\build-cache\$dname1)) {
-        7z x c:\build-cache\$bname -oc:\build-cache
-        move c:\build-cache\$dname0 c:\build-cache\$dname1
+$bname = "php-devel-pack-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "c:\build-cache\$bname")) {
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+    if (-not (Test-Path "c:\build-cache\$bname")) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    }
 }
-cd c:\projects\apcu
-$env:PATH = 'c:\build-cache\' + $dname1 + ';' + $env:PATH
-#echo "@echo off" | Out-File -Encoding "ASCII" task.bat
-#echo "" | Out-File -Encoding "ASCII" -Append task.bat
-echo "" | Out-File -Encoding "ASCII" task.bat
-echo "call phpize 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-echo "call configure --enable-apcu --enable-debug-pack 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-echo "nmake /nologo 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
-$here = (Get-Item -Path "." -Verbose).FullName
-$runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
-$task = $here + '\task.bat'
-& $runner -t $task
+$dname0 = "php-$env:PHP_VER-devel-$env:VC-$env:ARCH"
+$dname1 = "php-$env:PHP_VER$ts_part-devel-$env:VC-$env:ARCH"
+if (-not (Test-Path "c:\build-cache\$dname1")) {
+    Expand-Archive "c:\build-cache\$bname" "c:\build-cache"
+    Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
+}
+
+Set-Location 'c:\projects\apcu'
+$env:PATH = "c:\build-cache\$dname1;$env:PATH"
+
+$task = New-Item 'task.bat' -Force
+Add-Content $task "call phpize 2>&1"
+Add-Content $task "call configure --enable-apcu --enable-debug-pack 2>&1"
+Add-Content $task "nmake /nologo 2>&1"
+Add-Content $task "exit %errorlevel%"
+& "c:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -15,20 +15,20 @@ if (-not (Test-Path 'c:\build-cache\$dname1')) {
     Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
 }
 
+$releases = Invoke-WebRequest https://windows.php.net/downloads/releases/releases.json | ConvertFrom-Json
+$phpversion = $releases.$env:PHP_VER.version
+
 $ts_part = ''
 if ($env:TS -eq '0') {
     $ts_part += '-nts'
 }
 
-$bname = "php-devel-pack-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+$bname = "php-devel-pack-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
 if (-not (Test-Path "c:\build-cache\$bname")) {
-    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-    if (-not (Test-Path "c:\build-cache\$bname")) {
-        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-    }
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
 }
-$dname0 = "php-$env:PHP_VER-devel-$env:VC-$env:ARCH"
-$dname1 = "php-$env:PHP_VER$ts_part-devel-$env:VC-$env:ARCH"
+$dname0 = "php-$phpversion-devel-$env:VC-$env:ARCH"
+$dname1 = "php-$phpversion$ts_part-devel-$env:VC-$env:ARCH"
 if (-not (Test-Path "c:\build-cache\$dname1")) {
     Expand-Archive "c:\build-cache\$bname" "c:\build-cache"
     if ($dname0 -ne $dname1) {
@@ -37,14 +37,11 @@ if (-not (Test-Path "c:\build-cache\$dname1")) {
 }
 $env:PATH = "c:\build-cache\$dname1;$env:PATH"
 
-$bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+$bname = "php-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
 if (-not (Test-Path "c:\build-cache\$bname")) {
-    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-    if (-not (Test-Path "c:\build-cache\$bname")) {
-        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-    }
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
 }
-$dname = "php-$env:PHP_VER$ts_part-$env:VC-$env:ARCH"
+$dname = "php-$phpversion$ts_part-$env:VC-$env:ARCH"
 if (-not (Test-Path "c:\build-cache\$dname")) {
     Expand-Archive "c:\build-cache\$bname" "c:\build-cache\$dname"
 }

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -5,8 +5,9 @@ if (-not (Test-Path 'c:\build-cache')) {
 }
 
 $bname = "php-sdk-$env:BIN_SDK_VER.zip"
+Write-Host $bname
 if (-not (Test-Path c:\build-cache\$bname)) {
-    Invoke-WebRequest "https://github.com/OSTC/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
+    Invoke-WebRequest "https://github.com/microsoft/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
 }
 $dname0 = "php-sdk-binary-tools-php-sdk-$env:BIN_SDK_VER"
 $dname1 = "php-sdk-$env:BIN_SDK_VER"
@@ -15,8 +16,18 @@ if (-not (Test-Path 'c:\build-cache\$dname1')) {
     Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
 }
 
-$releases = Invoke-WebRequest https://windows.php.net/downloads/releases/releases.json | ConvertFrom-Json
-$phpversion = $releases.$env:PHP_VER.version
+$releases = @{
+    '7.0' = '7.0.33';
+    '7.1' = '7.1.33';
+}
+if ($releases.ContainsKey($env:PHP_VER)) {
+    $phpversion = $releases.$env:PHP_VER;
+    $base_url = 'http://windows.php.net/downloads/releases/archives';
+} else {
+    $releases = Invoke-WebRequest https://windows.php.net/downloads/releases/releases.json | ConvertFrom-Json
+    $phpversion = $releases.$env:PHP_VER.version
+    $base_url = 'http://windows.php.net/downloads/releases';
+}
 
 $ts_part = ''
 if ($env:TS -eq '0') {
@@ -25,7 +36,7 @@ if ($env:TS -eq '0') {
 
 $bname = "php-devel-pack-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
 if (-not (Test-Path "c:\build-cache\$bname")) {
-    Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    Invoke-WebRequest "$base_url/$bname" -OutFile "c:\build-cache\$bname"
 }
 $dname0 = "php-$phpversion-devel-$env:VC-$env:ARCH"
 $dname1 = "php-$phpversion$ts_part-devel-$env:VC-$env:ARCH"
@@ -39,7 +50,7 @@ $env:PATH = "c:\build-cache\$dname1;$env:PATH"
 
 $bname = "php-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
 if (-not (Test-Path "c:\build-cache\$bname")) {
-    Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    Invoke-WebRequest "$base_url/$bname" -OutFile "c:\build-cache\$bname"
 }
 $dname = "php-$phpversion$ts_part-$env:VC-$env:ARCH"
 if (-not (Test-Path "c:\build-cache\$dname")) {

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,0 +1,13 @@
+if (-not (Test-Path c:\build-cache)) {
+    mkdir c:\build-cache
+}
+$bname = 'php-sdk-' + $env:BIN_SDK_VER + '.zip'
+if (-not (Test-Path c:\build-cache\$bname)) {
+    Invoke-WebRequest "https://github.com/OSTC/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
+}
+$dname0 = 'php-sdk-binary-tools-php-sdk-' + $env:BIN_SDK_VER
+$dname1 = 'php-sdk-' + $env:BIN_SDK_VER
+if (-not (Test-Path c:\build-cache\$dname1)) {
+    7z x c:\build-cache\$bname -oc:\build-cache
+    move c:\build-cache\$dname0 c:\build-cache\$dname1
+}

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -3,6 +3,7 @@ $ErrorActionPreference = "Stop"
 if (-not (Test-Path 'c:\build-cache')) {
     [void](New-Item 'c:\build-cache' -ItemType 'directory')
 }
+
 $bname = "php-sdk-$env:BIN_SDK_VER.zip"
 if (-not (Test-Path c:\build-cache\$bname)) {
     Invoke-WebRequest "https://github.com/OSTC/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
@@ -13,3 +14,38 @@ if (-not (Test-Path 'c:\build-cache\$dname1')) {
     Expand-Archive "c:\build-cache\$bname" "c:\build-cache"
     Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
 }
+
+$ts_part = ''
+if ($env:TS -eq '0') {
+    $ts_part += '-nts'
+}
+
+$bname = "php-devel-pack-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "c:\build-cache\$bname")) {
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+    if (-not (Test-Path "c:\build-cache\$bname")) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    }
+}
+$dname0 = "php-$env:PHP_VER-devel-$env:VC-$env:ARCH"
+$dname1 = "php-$env:PHP_VER$ts_part-devel-$env:VC-$env:ARCH"
+if (-not (Test-Path "c:\build-cache\$dname1")) {
+    Expand-Archive "c:\build-cache\$bname" "c:\build-cache"
+    if ($dname0 -ne $dname1) {
+        Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
+    }
+}
+$env:PATH = "c:\build-cache\$dname1;$env:PATH"
+
+$bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "c:\build-cache\$bname")) {
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+    if (-not (Test-Path "c:\build-cache\$bname")) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    }
+}
+$dname = "php-$env:PHP_VER$ts_part-$env:VC-$env:ARCH"
+if (-not (Test-Path "c:\build-cache\$dname")) {
+    Expand-Archive "c:\build-cache\$bname" "c:\build-cache\$dname"
+}
+$env:PATH = "c:\build-cache\$dname;$env:PATH"

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 if (-not (Test-Path 'c:\build-cache')) {
     [void](New-Item 'c:\build-cache' -ItemType 'directory')
 }

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,13 +1,13 @@
-if (-not (Test-Path c:\build-cache)) {
-    mkdir c:\build-cache
+if (-not (Test-Path 'c:\build-cache')) {
+    [void](New-Item 'c:\build-cache' -ItemType 'directory')
 }
-$bname = 'php-sdk-' + $env:BIN_SDK_VER + '.zip'
+$bname = "php-sdk-$env:BIN_SDK_VER.zip"
 if (-not (Test-Path c:\build-cache\$bname)) {
     Invoke-WebRequest "https://github.com/OSTC/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
 }
-$dname0 = 'php-sdk-binary-tools-php-sdk-' + $env:BIN_SDK_VER
-$dname1 = 'php-sdk-' + $env:BIN_SDK_VER
-if (-not (Test-Path c:\build-cache\$dname1)) {
-    7z x c:\build-cache\$bname -oc:\build-cache
-    move c:\build-cache\$dname0 c:\build-cache\$dname1
+$dname0 = "php-sdk-binary-tools-php-sdk-$env:BIN_SDK_VER"
+$dname1 = "php-sdk-$env:BIN_SDK_VER"
+if (-not (Test-Path 'c:\build-cache\$dname1')) {
+    Expand-Archive "c:\build-cache\$bname" "c:\build-cache"
+    Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
 }

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -1,9 +1,15 @@
 $ts_part = 'ts'
-if ('0' -eq $env:TS) { $ts_part = 'nts' }
-$zip_bname = 'php_apcu-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + '-' + $ts_part + '-' + $env:VC + '-' + $env:ARCH + '.zip'
-$dir = 'c:\projects\apcu\';
-if ('x64' -eq $env:ARCH) { $dir = $dir + 'x64\' }
-$dir = $dir + 'Release'
-if ('1' -eq $env:TS) { $dir = $dir + '_TS' }
-& 7z a c:\$zip_bname $dir\php_apcu.dll $dir\php_apcu.pdb c:\projects\apcu\LICENSE
-Push-AppveyorArtifact c:\$zip_bname
+if ($env:TS -eq '0') {
+    $ts_part += 'nts'
+}
+$zip_bname = 'php_apcu-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + "-$ts_part-$env:VC-$env:ARCH.zip"
+$dir = 'c:\projects\apcu\'
+if ($env:ARCH -eq 'x64') {
+    $dir += 'x64\'
+}
+$dir += 'Release'
+if ($env:TS -eq '1') {
+    $dir += '_TS'
+}
+Compress-Archive @("$dir\php_apcu.dll", "$dir\php_apcu.pdb", "c:\projects\apcu\LICENSE") "c:\$zip_bname"
+Push-AppveyorArtifact "c:\$zip_bname"

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $ts_part = 'ts'
 if ($env:TS -eq '0') {
     $ts_part += 'nts'

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -1,0 +1,9 @@
+$ts_part = 'ts'
+if ('0' -eq $env:TS) { $ts_part = 'nts' }
+$zip_bname = 'php_apcu-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + '-' + $ts_part + '-' + $env:VC + '-' + $env:ARCH + '.zip'
+$dir = 'c:\projects\apcu\';
+if ('x64' -eq $env:ARCH) { $dir = $dir + 'x64\' }
+$dir = $dir + 'Release'
+if ('1' -eq $env:TS) { $dir = $dir + '_TS' }
+& 7z a c:\$zip_bname $dir\php_apcu.dll $dir\php_apcu.pdb c:\projects\apcu\LICENSE
+Push-AppveyorArtifact c:\$zip_bname

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -4,7 +4,9 @@ $ts_part = 'ts'
 if ($env:TS -eq '0') {
     $ts_part += 'nts'
 }
-$zip_bname = 'php_apcu-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + "-$ts_part-$env:VC-$env:ARCH.zip"
+$commit = $env:APPVEYOR_REPO_COMMIT.substring(0, 8)
+$zip_bname = "php_apcu-$commit-$env:PHP_VER-$ts_part-$env:VC-$env:ARCH.zip"
+
 $dir = 'c:\projects\apcu\'
 if ($env:ARCH -eq 'x64') {
     $dir += 'x64\'
@@ -13,5 +15,6 @@ $dir += 'Release'
 if ($env:TS -eq '1') {
     $dir += '_TS'
 }
+
 Compress-Archive @("$dir\php_apcu.dll", "$dir\php_apcu.pdb", "c:\projects\apcu\LICENSE") "c:\$zip_bname"
 Push-AppveyorArtifact "c:\$zip_bname"

--- a/.appveyor/test.ps1
+++ b/.appveyor/test.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $ts_part = ''
 if ($env:TS -eq '0') {
     $ts_part += '-nts'
@@ -20,3 +22,6 @@ Add-Content $task "call configure --enable-apcu --with-prefix=c:\build-cache\$dn
 Add-Content $task "nmake /nologo test TESTS=-q 2>&1"
 Add-Content $task "exit %errorlevel%"
 & "c:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task
+if (-not $?) {
+    throw "tests failed with errorlevel $LastExitCode"
+}

--- a/.appveyor/test.ps1
+++ b/.appveyor/test.ps1
@@ -1,27 +1,9 @@
 $ErrorActionPreference = "Stop"
 
-$ts_part = ''
-if ($env:TS -eq '0') {
-    $ts_part += '-nts'
-}
-$bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
-if (-not (Test-Path "c:\build-cache\$bname")) {
-    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-    if (-not (Test-Path "c:\build-cache\$bname")) {
-        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-    }
-}
-$dname = "php-$env:PHP_VER$ts_part-$env:VC-$env:ARCH"
-if (-not (Test-Path "c:\build-cache\$dname")) {
-    Expand-Archive "c:\build-cache\$bname" "c:\build-cache\$dname"
-}
 Set-Location 'c:\projects\apcu'
-$task = New-Item 'task.bat' -Force
-Add-Content $task "set REPORT_EXIT_STATUS=1"
-Add-Content $task "call configure --enable-apcu --with-prefix=c:\build-cache\$dname 2>&1"
-Add-Content $task "nmake /nologo test TESTS=-q 2>&1"
-Add-Content $task "exit %errorlevel%"
-& "c:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task
+
+$env:TEST_PHP_EXECUTABLE = Get-Command 'php' | Select-Object -ExpandProperty 'Definition'
+& $env:TEST_PHP_EXECUTABLE 'run-tests.php' --show-diff tests
 if (-not $?) {
     throw "tests failed with errorlevel $LastExitCode"
 }

--- a/.appveyor/test.ps1
+++ b/.appveyor/test.ps1
@@ -1,0 +1,24 @@
+$ts_part = ''
+if ('0' -eq $env:TS) { $ts_part = '-nts' }
+$bname = 'php-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
+if (-not (Test-Path c:\build-cache\$bname)) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+        if (-not (Test-Path c:\build-cache\$bname)) {
+                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+        }
+}
+$dname = 'php-' + $env:PHP_VER + $ts_part + '-' + $env:VC.toUpper() + '-' + $env:ARCH
+if (-not (Test-Path c:\build-cache\$dname)) {
+        7z x c:\build-cache\$bname -oc:\build-cache\$dname
+}
+cd c:\projects\apcu
+echo "" | Out-File -Encoding "ASCII" task.bat
+echo "set REPORT_EXIT_STATUS=1" | Out-File -Encoding "ASCII" -Append task.bat
+$cmd = 'call configure --enable-apcu --with-prefix=c:\build-cache\' + $dname + " 2>&1"
+echo $cmd | Out-File -Encoding "ASCII" -Append task.bat
+echo "nmake /nologo test TESTS=-q 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
+echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
+$here = (Get-Item -Path "." -Verbose).FullName
+$runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
+$task = $here + '\task.bat'
+& $runner -t $task

--- a/.appveyor/test.ps1
+++ b/.appveyor/test.ps1
@@ -1,24 +1,22 @@
 $ts_part = ''
-if ('0' -eq $env:TS) { $ts_part = '-nts' }
-$bname = 'php-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
-if (-not (Test-Path c:\build-cache\$bname)) {
-        Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-        if (-not (Test-Path c:\build-cache\$bname)) {
-                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-        }
+if ($env:TS -eq '0') {
+    $ts_part += '-nts'
 }
-$dname = 'php-' + $env:PHP_VER + $ts_part + '-' + $env:VC.toUpper() + '-' + $env:ARCH
-if (-not (Test-Path c:\build-cache\$dname)) {
-        7z x c:\build-cache\$bname -oc:\build-cache\$dname
+$bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "c:\build-cache\$bname")) {
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+    if (-not (Test-Path "c:\build-cache\$bname")) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    }
 }
-cd c:\projects\apcu
-echo "" | Out-File -Encoding "ASCII" task.bat
-echo "set REPORT_EXIT_STATUS=1" | Out-File -Encoding "ASCII" -Append task.bat
-$cmd = 'call configure --enable-apcu --with-prefix=c:\build-cache\' + $dname + " 2>&1"
-echo $cmd | Out-File -Encoding "ASCII" -Append task.bat
-echo "nmake /nologo test TESTS=-q 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
-$here = (Get-Item -Path "." -Verbose).FullName
-$runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
-$task = $here + '\task.bat'
-& $runner -t $task
+$dname = "php-$env:PHP_VER$ts_part-$env:VC-$env:ARCH"
+if (-not (Test-Path "c:\build-cache\$dname")) {
+    Expand-Archive "c:\build-cache\$bname" "c:\build-cache\$dname"
+}
+Set-Location 'c:\projects\apcu'
+$task = New-Item 'task.bat' -Force
+Add-Content $task "set REPORT_EXIT_STATUS=1"
+Add-Content $task "call configure --enable-apcu --with-prefix=c:\build-cache\$dname 2>&1"
+Add-Content $task "nmake /nologo test TESTS=-q 2>&1"
+Add-Content $task "exit %errorlevel%"
+& "c:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,86 +2,86 @@ version: "{branch}.build.{build}"
 skip_tags: true
 
 branches:
-        only:
-                - master
+  only:
+    - master
 
 clone_folder:  c:\projects\apcu
 
 install:
-        ps: .appveyor\install.ps1
+  ps: .appveyor\install.ps1
 
 cache:
-        c:\build-cache -> appveyor.yml, .appveyor\install.ps1
+  c:\build-cache -> appveyor.yml, .appveyor\install.ps1
 
 environment:
-        BIN_SDK_VER: 2.1.1
-        matrix:
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x64
-                  VC: vc14
-                  PHP_VER: 7.0.27
-                  TS: 0
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x64
-                  VC: vc14
-                  PHP_VER: 7.0.27
-                  TS: 1
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x86
-                  VC: vc14
-                  PHP_VER: 7.0.27
-                  TS: 0
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x86
-                  VC: vc14
-                  PHP_VER: 7.0.27
-                  TS: 1
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x64
-                  VC: vc14
-                  PHP_VER: 7.1.14
-                  TS: 0
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x64
-                  VC: vc14
-                  PHP_VER: 7.1.14
-                  TS: 1
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x86
-                  VC: vc14
-                  PHP_VER: 7.1.14
-                  TS: 0
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x86
-                  VC: vc14
-                  PHP_VER: 7.1.14
-                  TS: 1
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-                  ARCH: x64
-                  VC: vc15
-                  PHP_VER: 7.2.2
-                  TS: 0
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-                  ARCH: x64
-                  VC: vc15
-                  PHP_VER: 7.2.2
-                  TS: 1
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-                  ARCH: x86
-                  VC: vc15
-                  PHP_VER: 7.2.2
-                  TS: 0
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-                  ARCH: x86
-                  VC: vc15
-                  PHP_VER: 7.2.2
-                  TS: 1
+  BIN_SDK_VER: 2.1.2
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.2
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.2
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.2
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.2
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.3
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.3
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.3
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.3
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.4
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.4
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.4
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.4
+      TS: 1
 
 build_script:
-        ps: .appveyor\build.ps1
+  ps: .appveyor\build.ps1
 
 after_build:
-        ps: .appveyor\package.ps1
+  ps: .appveyor\package.ps1
 
 test_script:
-        ps: .appveyor\test.ps1
+  ps: .appveyor\test.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,23 +8,10 @@ branches:
 clone_folder:  c:\projects\apcu
 
 install:
-        ps: |
-                if (-not (Test-Path c:\build-cache)) {
-                        mkdir c:\build-cache
-                }
-                $bname = 'php-sdk-' + $env:BIN_SDK_VER + '.zip'
-                if (-not (Test-Path c:\build-cache\$bname)) {
-                        Invoke-WebRequest "https://github.com/OSTC/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
-                }
-                $dname0 = 'php-sdk-binary-tools-php-sdk-' + $env:BIN_SDK_VER
-                $dname1 = 'php-sdk-' + $env:BIN_SDK_VER
-                if (-not (Test-Path c:\build-cache\$dname1)) {
-                        7z x c:\build-cache\$bname -oc:\build-cache
-                        move c:\build-cache\$dname0 c:\build-cache\$dname1
-                }
+        ps: .appveyor\install.ps1
 
 cache:
-        c:\build-cache -> .appveyor.yml
+        c:\build-cache -> appveyor.yml, .appveyor\install.ps1, .appveyor\build.ps1, .appveyor\test.ps1
 
 environment:
         BIN_SDK_VER: 2.1.1
@@ -91,72 +78,10 @@ environment:
                   TS: 1
 
 build_script:
-        ps: |
-                $ts_part = ''
-                if ('0' -eq $env:TS) { $ts_part = '-nts' }
-                $bname = 'php-devel-pack-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
-                if (-not (Test-Path c:\build-cache\$bname)) {
-                        Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-                        if (-not (Test-Path c:\build-cache\$bname)) {
-                                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-                        }
-                }
-                $dname0 = 'php-' + $env:PHP_VER + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
-                $dname1 = 'php-' + $env:PHP_VER + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
-                if (-not (Test-Path c:\build-cache\$dname1)) {
-                        7z x c:\build-cache\$bname -oc:\build-cache
-                        move c:\build-cache\$dname0 c:\build-cache\$dname1
-                }
-                cd c:\projects\apcu
-                $env:PATH = 'c:\build-cache\' + $dname1 + ';' + $env:PATH
-                #echo "@echo off" | Out-File -Encoding "ASCII" task.bat
-                #echo "" | Out-File -Encoding "ASCII" -Append task.bat
-                echo "" | Out-File -Encoding "ASCII" task.bat
-                echo "call phpize 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-                echo "call configure --enable-apcu --enable-debug-pack 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-                echo "nmake /nologo 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-                echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
-                $here = (Get-Item -Path "." -Verbose).FullName
-                $runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
-                $task = $here + '\task.bat'
-                & $runner -t $task
+        ps: .appveyor\build.ps1
 
 after_build:
-        ps: |
-                $ts_part = 'ts'
-                if ('0' -eq $env:TS) { $ts_part = 'nts' }
-                $zip_bname = 'php_apcu-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + '-' + $ts_part + '-' + $env:VC + '-' + $env:ARCH + '.zip'
-                $dir = 'c:\projects\apcu\';
-                if ('x64' -eq $env:ARCH) { $dir = $dir + 'x64\' }
-                $dir = $dir + 'Release'
-                if ('1' -eq $env:TS) { $dir = $dir + '_TS' }
-                & 7z a c:\$zip_bname $dir\php_apcu.dll $dir\php_apcu.pdb c:\projects\apcu\LICENSE
-                Push-AppveyorArtifact c:\$zip_bname
+        ps: .appveyor\package.ps1
 
 test_script:
-        ps: |
-                $ts_part = ''
-                if ('0' -eq $env:TS) { $ts_part = '-nts' }
-                $bname = 'php-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
-                if (-not (Test-Path c:\build-cache\$bname)) {
-                        Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-                        if (-not (Test-Path c:\build-cache\$bname)) {
-                                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-                        }
-                }
-                $dname = 'php-' + $env:PHP_VER + $ts_part + '-' + $env:VC.toUpper() + '-' + $env:ARCH
-                if (-not (Test-Path c:\build-cache\$dname)) {
-                        7z x c:\build-cache\$bname -oc:\build-cache\$dname
-                }
-                cd c:\projects\apcu
-                echo "" | Out-File -Encoding "ASCII" task.bat
-                echo "set REPORT_EXIT_STATUS=1" | Out-File -Encoding "ASCII" -Append task.bat
-                $cmd = 'call configure --enable-apcu --with-prefix=c:\build-cache\' + $dname + " 2>&1"
-                echo $cmd | Out-File -Encoding "ASCII" -Append task.bat
-                echo "nmake /nologo test TESTS=-q 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-                echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
-                $here = (Get-Item -Path "." -Verbose).FullName
-                $runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
-                $task = $here + '\task.bat'
-                & $runner -t $task
-
+        ps: .appveyor\test.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
         ps: .appveyor\install.ps1
 
 cache:
-        c:\build-cache -> appveyor.yml, .appveyor\install.ps1, .appveyor\build.ps1, .appveyor\test.ps1
+        c:\build-cache -> appveyor.yml, .appveyor\install.ps1
 
 environment:
         BIN_SDK_VER: 2.1.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,18 @@ cache:
   c:\build-cache -> appveyor.yml, .appveyor\install.ps1
 
 environment:
-  BIN_SDK_VER: 2.1.2
+  BIN_SDK_VER: 2.2.0
   matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ARCH: x64
+      VC: vc14
+      PHP_VER: 7.0
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ARCH: x64
+      VC: vc14
+      PHP_VER: 7.1
+      TS: 0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARCH: x64
       VC: vc15

--- a/tests/server_test.inc
+++ b/tests/server_test.inc
@@ -44,6 +44,7 @@ function server_start_one($host, $port, $code = 'echo "Hello world";', $php_opts
 			$cmd .= " {$router}";
 		}
 
+		$descriptorspec[2] = array('pipe', 'w');
 		$handle = proc_open(addslashes($cmd), $descriptorspec, $pipes, $doc_root, NULL, array("bypass_shell" => true,  "suppress_errors" => true));
 	} else {
 		$cmd = "exec {$php_executable} -n $php_args -t {$doc_root} -S $host:$port";


### PR DESCRIPTION
This PR is mainly about updating the PHP versions for the builds (was 7.0-7.2, now 7.2-7.4), but also improves maintainability of the AppVeyor script, and fixes the test failures on PHP 7.4.