### PR TITLE
Raise error on invalid serializer.

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -1218,6 +1218,9 @@ PHP_APCU_API zend_bool apc_cache_defense(apc_cache_t *cache, zend_string *key, t
 PHP_APCU_API void apc_cache_serializer(apc_cache_t* cache, const char* name) {
 	if (cache && !cache->serializer) {
 		cache->serializer = apc_find_serializer(name);
+		if (strcmp(name, "default") != 0 && !cache->serializer) {
+			php_error_docref(NULL, E_WARNING, "apc_cache_serializer: serializer \"%s\" is not supported.", name);
+		}
 	}
 } /* }}} */
 

--- a/tests/serializer_invalid.phpt
+++ b/tests/serializer_invalid.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Serializer: invalid pattern.
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.serializer=igbinary
+--FILE--
+<?php
+--EXPECT--
+Warning: Unknown: apc_cache_serializer: serializer "igbinary" is not supported. in Unknown on line 0

--- a/tests/serializer_valid.phpt
+++ b/tests/serializer_valid.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Serializer: valid pattern.
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.serializer=php
+--FILE--
+<?php
+--EXPECT--


### PR DESCRIPTION
APCu works with the default serializer, even if the value set in apc.serializer is invalid.

But, this is unfriendly if you are using a third party serializer such as igbinary. For example, if igbinary is installed before APCu is installed, igbinary will not support APCu. The current behavior of working with the default serializer without warning may produce unintended behavior.

This fix changes it to give an E_WARNING equivalent warning if an unavailable serializer is specified.