### PR TITLE
Fix AppVeyor CI build for PHP 7.3

### DIFF
--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -20,6 +20,7 @@ $releases = @{
     '7.0' = '7.0.33';
     '7.1' = '7.1.33';
     '7.2' = '7.2.34';
+    '7.3' = '7.3.33';
 }
 if ($releases.ContainsKey($env:PHP_VER)) {
     $phpversion = $releases.$env:PHP_VER;


### PR DESCRIPTION
PHP 7.3 is EOL, so the builds have been moved to the archives; we need
to cater to that.

---

An alternative might be to drop AppVeyor CI in favor of GH actions altogether.
