### PR TITLE
Switch to modern parameters parsing API

### DIFF
--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -393,8 +393,9 @@ PHP_METHOD(APCUIterator, __construct) {
 PHP_METHOD(APCUIterator, rewind) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -407,8 +408,9 @@ PHP_METHOD(APCUIterator, rewind) {
 PHP_METHOD(APCUIterator, valid) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -423,8 +425,9 @@ PHP_METHOD(APCUIterator, current) {
 	apc_iterator_item_t *item;
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -443,8 +446,9 @@ PHP_METHOD(APCUIterator, key) {
 	apc_iterator_item_t *item;
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	ENSURE_INITIALIZED(iterator);
 	if (apc_stack_size(iterator->stack) == iterator->stack_idx) {
@@ -466,8 +470,9 @@ PHP_METHOD(APCUIterator, key) {
 PHP_METHOD(APCUIterator, next) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	ENSURE_INITIALIZED(iterator);
 	if (apc_stack_size(iterator->stack) == 0) {
@@ -481,8 +486,9 @@ PHP_METHOD(APCUIterator, next) {
 PHP_METHOD(APCUIterator, getTotalHits) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -497,8 +503,9 @@ PHP_METHOD(APCUIterator, getTotalHits) {
 PHP_METHOD(APCUIterator, getTotalSize) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -512,8 +519,9 @@ PHP_METHOD(APCUIterator, getTotalSize) {
 PHP_METHOD(APCUIterator, getTotalCount) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	ENSURE_INITIALIZED(iterator);
 

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -374,9 +374,13 @@ PHP_METHOD(APCUIterator, __construct) {
 	zval *search = NULL;
 	zend_long list = APC_LIST_ACTIVE;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|z!lll", &search, &format, &chunk_size, &list) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 4)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL_EX(search, 1, 0)
+		Z_PARAM_LONG(format)
+		Z_PARAM_LONG(chunk_size)
+		Z_PARAM_LONG(list)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (chunk_size < 0) {
 		apc_error("APCUIterator chunk size must be 0 or greater");
@@ -389,9 +393,8 @@ PHP_METHOD(APCUIterator, __construct) {
 PHP_METHOD(APCUIterator, rewind) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -404,9 +407,8 @@ PHP_METHOD(APCUIterator, rewind) {
 PHP_METHOD(APCUIterator, valid) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -421,9 +423,8 @@ PHP_METHOD(APCUIterator, current) {
 	apc_iterator_item_t *item;
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -442,9 +443,8 @@ PHP_METHOD(APCUIterator, key) {
 	apc_iterator_item_t *item;
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	ENSURE_INITIALIZED(iterator);
 	if (apc_stack_size(iterator->stack) == iterator->stack_idx) {
@@ -466,9 +466,8 @@ PHP_METHOD(APCUIterator, key) {
 PHP_METHOD(APCUIterator, next) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	ENSURE_INITIALIZED(iterator);
 	if (apc_stack_size(iterator->stack) == 0) {
@@ -482,9 +481,8 @@ PHP_METHOD(APCUIterator, next) {
 PHP_METHOD(APCUIterator, getTotalHits) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -499,9 +497,8 @@ PHP_METHOD(APCUIterator, getTotalHits) {
 PHP_METHOD(APCUIterator, getTotalSize) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	ENSURE_INITIALIZED(iterator);
 
@@ -515,9 +512,8 @@ PHP_METHOD(APCUIterator, getTotalSize) {
 PHP_METHOD(APCUIterator, getTotalCount) {
 	apc_iterator_t *iterator = apc_iterator_fetch(getThis());
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	ENSURE_INITIALIZED(iterator);
 

--- a/apcue/apcue.c
+++ b/apcue/apcue.c
@@ -134,9 +134,9 @@ PHP_FUNCTION(apcue_get)
 	char*      key = NULL;
 	zend_uint  klen = 0L;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &klen) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STRING(key, klen)
+	ZEND_PARSE_PARAMETERS_END();
 
 	{
 		/* perform lookup */
@@ -155,10 +155,13 @@ PHP_FUNCTION(apcue_set)
 	zend_uint  klen = 0L;
     long       ttl = 0L;
     zval*      pzval = NULL;
-	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz|l", &key, &klen, &pzval, &ttl) == FAILURE) {
-		return;
-	}
+
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_STRING(key, klen)
+		Z_PARAM_ZVAL(pzval)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(ttl)
+	ZEND_PARSE_PARAMETERS_END();
 
 	/* perform store */
 	ZVAL_BOOL(return_value, apc_cache_store(apcue_cache, key, klen, pzval, ttl, 0 TSRMLS_CC));

--- a/php_apc.c
+++ b/php_apc.c
@@ -336,8 +336,9 @@ static PHP_RINIT_FUNCTION(apcu)
 /* {{{ proto void apcu_clear_cache() */
 PHP_FUNCTION(apcu_clear_cache)
 {
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 
 	apc_cache_clear(apc_user_cache);
 	RETURN_TRUE;
@@ -502,8 +503,9 @@ static void apc_store_helper(INTERNAL_FUNCTION_PARAMETERS, const zend_bool exclu
 /* {{{ proto bool apcu_enabled(void)
 	returns true when apcu is usable in the current environment */
 PHP_FUNCTION(apcu_enabled) {
-	ZEND_PARSE_PARAMETERS_START(0, 0)
-	ZEND_PARSE_PARAMETERS_END();
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
 	RETURN_BOOL(APCG(enabled));
 }
 /* }}} */

--- a/php_apc.c
+++ b/php_apc.c
@@ -336,9 +336,8 @@ static PHP_RINIT_FUNCTION(apcu)
 /* {{{ proto void apcu_clear_cache() */
 PHP_FUNCTION(apcu_clear_cache)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
 	apc_cache_clear(apc_user_cache);
 	RETURN_TRUE;
@@ -350,9 +349,10 @@ PHP_FUNCTION(apcu_cache_info)
 {
 	zend_bool limited = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &limited) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0,1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(limited)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (!apc_cache_info(return_value, apc_user_cache, limited)) {
 		php_error_docref(NULL, E_WARNING, "No APC info available.  Perhaps APC is not enabled? Check apc.enabled in your ini file");
@@ -366,9 +366,9 @@ PHP_FUNCTION(apcu_key_info)
 {
 	zend_string *key;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &key) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(key)
+	ZEND_PARSE_PARAMETERS_END();
 
 	apc_cache_stat(apc_user_cache, key, return_value);
 } /* }}} */
@@ -381,9 +381,10 @@ PHP_FUNCTION(apcu_sma_info)
 	int i;
 	zend_bool limited = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &limited) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(limited)
+	ZEND_PARSE_PARAMETERS_END();
 
 	info = apc_sma_info(&apc_sma, limited);
 
@@ -447,9 +448,12 @@ static void apc_store_helper(INTERNAL_FUNCTION_PARAMETERS, const zend_bool exclu
 	zval *val = NULL;
 	zend_long ttl = 0L;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|zl", &key, &val, &ttl) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 3)
+		Z_PARAM_ZVAL(key)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(val)
+		Z_PARAM_LONG(ttl)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (APCG(serializer_name)) {
 		/* Avoid race conditions between MINIT of apc and serializer exts like igbinary */
@@ -498,9 +502,8 @@ static void apc_store_helper(INTERNAL_FUNCTION_PARAMETERS, const zend_bool exclu
 /* {{{ proto bool apcu_enabled(void)
 	returns true when apcu is usable in the current environment */
 PHP_FUNCTION(apcu_enabled) {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 	RETURN_BOOL(APCG(enabled));
 }
 /* }}} */
@@ -540,9 +543,13 @@ PHP_FUNCTION(apcu_inc) {
 	zend_long step = 1, ttl = 0;
 	zval *success = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|lzl", &key, &step, &success, &ttl) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 4)
+		Z_PARAM_STR(key)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(step)
+		Z_PARAM_ZVAL(success)
+		Z_PARAM_LONG(ttl)
+	ZEND_PARSE_PARAMETERS_END();
 
 	args.step = step;
 	if (php_apc_update(key, php_inc_updater, &args, 1, ttl)) {
@@ -568,9 +575,13 @@ PHP_FUNCTION(apcu_dec) {
 	zend_long step = 1, ttl = 0;
 	zval *success = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|lzl", &key, &step, &success, &ttl) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 4)
+		Z_PARAM_STR(key)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(step)
+		Z_PARAM_ZVAL(success)
+		Z_PARAM_LONG(ttl)
+	ZEND_PARSE_PARAMETERS_END();
 
 	args.step = 0 - step;
 	if (php_apc_update(key, php_inc_updater, &args, 1, ttl)) {
@@ -604,9 +615,11 @@ PHP_FUNCTION(apcu_cas) {
 	zend_string *key;
 	zend_long vals[2];
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sll", &key, &vals[0], &vals[1]) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_STR(key)
+		Z_PARAM_LONG(vals[0])
+		Z_PARAM_LONG(vals[1])
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (APCG(serializer_name)) {
 		/* Avoid race conditions between MINIT of apc and serializer exts like igbinary */
@@ -625,9 +638,11 @@ PHP_FUNCTION(apcu_fetch) {
 	time_t t;
 	int result;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|z", &key, &success) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_ZVAL(key)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(success)
+	ZEND_PARSE_PARAMETERS_END();
 
 	t = apc_time();
 
@@ -676,9 +691,9 @@ PHP_FUNCTION(apcu_exists) {
 	zval *key;
 	time_t t;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &key) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(key)
+	ZEND_PARSE_PARAMETERS_END();
 
 	t = apc_time();
 
@@ -718,9 +733,9 @@ PHP_FUNCTION(apcu_exists) {
 PHP_FUNCTION(apcu_delete) {
 	zval *keys;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &keys) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(keys)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (Z_TYPE_P(keys) == IS_STRING) {
 		RETURN_BOOL(apc_cache_delete(apc_user_cache, Z_STR_P(keys)));
@@ -754,9 +769,12 @@ PHP_FUNCTION(apcu_entry) {
 	zend_long ttl = 0L;
 	zend_long now = apc_time();
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sf|l", &key, &fci, &fcc, &ttl) != SUCCESS) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_STR(key)
+		Z_PARAM_FUNC(fci, fcc)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(ttl)
+	ZEND_PARSE_PARAMETERS_END();
 
 	apc_cache_entry(apc_user_cache, key, &fci, &fcc, ttl, now, return_value);
 }
@@ -767,9 +785,10 @@ PHP_FUNCTION(apcu_entry) {
 PHP_FUNCTION(apcu_inc_request_time) {
 	zend_long by = 1;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &by) != SUCCESS) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(by)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (!APCG(use_request_time)) {
 		php_error_docref(NULL, E_WARNING,


### PR DESCRIPTION
https://github.com/php/php-src/blob/master/docs/parameter-parsing-api.md

I used very simple and naive way to get some idea of performance improvements:

```
<?php

$ts = microtime(true);

$r1 = apcu_store('test_key', 'test_value');

var_dump($r1);

for ($i = 0; $i < 10_000_000; $i++) {
        $r2 = apcu_fetch('test_key');
}
var_dump($r2);
printf("%0.6f\n", microtime(true) - $ts);
```


Before: 
```
bool(true)
string(10) "test_value"
3.218031

bool(true)
string(10) "test_value"
3.236936

bool(true)
string(10) "test_value"
3.164991

bool(true)
string(10) "test_value"
3.315372
```


After:

```
bool(true)
string(10) "test_value"
2.996424

bool(true)
string(10) "test_value"
2.872444

bool(true)
string(10) "test_value"
2.991932

bool(true)
string(10) "test_value"
2.961243
```

