### PR TITLE
Reuse the immutable empty array in apcu_fetch

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -82,6 +82,7 @@
     <file name="apc_entry_002.phpt" role="test" />
     <file name="apc_entry_003.phpt" role="test" />
     <file name="apc_entry_recursion.phpt" role="test" />
+    <file name="apcu_fetch_empty_array_reference.phpt" role="test" />
     <file name="apc_inc_perf.phpt" role="test" />
     <file name="apc_store_array_int_keys.phpt" role="test" />
     <file name="apc_store_array_with_refs.phpt" role="test" />
@@ -718,7 +719,7 @@ and unpersisting values.
   - Bring back spinlocks, various issues (Joe)
   - Fixed symbol clashing, windows debug mode, again (Anatol)
   - apcu_key_info / apc_cache_stat functions (Joe)
-  
+
    </notes>
   </release>
   <release>

--- a/tests/apcu_fetch_empty_array_reference.phpt
+++ b/tests/apcu_fetch_empty_array_reference.phpt
@@ -1,0 +1,55 @@
+--TEST--
+apcu_fetch should work for multiple reference groups
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+--FILE--
+<?php
+
+$x = [];
+$y = [];
+$array = [&$x, &$x, &$y, &$y];
+apcu_store("ary", $array);
+$copy = apcu_fetch("ary");
+$copy[0][1] = new stdClass();
+var_dump($array);
+var_dump($copy);
+
+?>
+--EXPECT--
+array(4) {
+  [0]=>
+  &array(0) {
+  }
+  [1]=>
+  &array(0) {
+  }
+  [2]=>
+  &array(0) {
+  }
+  [3]=>
+  &array(0) {
+  }
+}
+array(4) {
+  [0]=>
+  &array(1) {
+    [1]=>
+    object(stdClass)#1 (0) {
+    }
+  }
+  [1]=>
+  &array(1) {
+    [1]=>
+    object(stdClass)#1 (0) {
+    }
+  }
+  [2]=>
+  &array(0) {
+  }
+  [3]=>
+  &array(0) {
+  }
+}


### PR DESCRIPTION
Instead of allocating brand new arrays or looking them up in the hash map, return php's shared immutable empty array starting in php 7.3.

For #323