### PR TITLE
Fix bug in serializing php 8.2 lists, reduce memory usage.

### DIFF
--- a/tests/apc_025.phpt
+++ b/tests/apc_025.phpt
@@ -1,0 +1,33 @@
+--TEST--
+APC: apcu_fetch of packed array
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+--FILE--
+<?php
+var_dump(apcu_store('foo', [1, 2, 3, 4, 5, 6, 7, 8]));
+var_dump(apcu_fetch('foo'));
+
+?>
+--EXPECT--
+bool(true)
+array(8) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  int(4)
+  [4]=>
+  int(5)
+  [5]=>
+  int(6)
+  [6]=>
+  int(7)
+  [7]=>
+  int(8)
+}

--- a/tests/server_test.inc
+++ b/tests/server_test.inc
@@ -55,11 +55,12 @@ function server_start_one($host, $port, $code = 'echo "Hello world";', $php_opts
 
 		$handle = proc_open($cmd, $descriptorspec, $pipes, $doc_root);
 	}
-	
+
 	// note: even when server prints 'Listening on localhost:8964...Press Ctrl-C to quit.'
 	//       it might not be listening yet...need to wait until fsockopen() call returns
+	// Let this wait for up to 10 seconds to avoid spurious failures with valgrind.
     $i = 0;
-    while (($i++ < 10) && !connection_test($host, $port)) {
+    while (($i++ < 100) && !connection_test($host, $port)) {
         usleep(100000);
     }
 
@@ -78,7 +79,7 @@ function server_start($code = 'echo "Hello world";', $php_opts = array(), $no_ro
 	for ($i = 0; $i < $num_servers; $i++) {
 		$h = server_start_one(PHP_CLI_SERVER_HOSTNAME, PHP_CLI_SERVER_PORT+$i, $code, $php_opts, $no_router);
 		$handles[] = $h;
-	}	
+	}
 
 	register_shutdown_function(
 		function($handles) use($router) {


### PR DESCRIPTION
Starting in php 8.2, zvals are stored instead of Buckets, halving the memory usage per extra element. Use the same memory allocation when unserializing data and when storing data in shared memory in php 8.2.

This was previously copying too much data when there was an associative array instead of a list, and apc_025.phpt would fail with valgrind.

Related to #323