### PR TITLE
Add editorconfig file for APCu

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+; 4 space indentation (no size specified)
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+[*.{php,c,h,m4,w32,md}]
+trim_trailing_whitespace = true
+[*.{phpt,php}]
+indent_style = space
+[*.xml]
+indent_size = 1
+indent_style = space
+[*.m4]
+indent_size = 2
+indent_style = space
+[*.w32]
+charset = utf-8
+indent_style = tab
+indent_size = 2

--- a/apc_mutex.h
+++ b/apc_mutex.h
@@ -50,8 +50,8 @@ typedef apc_lock_t apc_mutex_t;
 
 // Fallback to normal locks
 
-#define APC_MUTEX_INIT()          
-#define APC_MUTEX_CLEANUP()       
+#define APC_MUTEX_INIT()
+#define APC_MUTEX_CLEANUP()
 
 #define APC_CREATE_MUTEX(lock)    CREATE_LOCK(lock)
 #define APC_DESTROY_MUTEX(lock)   DESTROY_LOCK(lock)

--- a/config.m4
+++ b/config.m4
@@ -18,7 +18,7 @@ AC_ARG_ENABLE(apcu-debug,
 [  --enable-apcu-debug     Enable APCu debugging],
 [
   PHP_APCU_DEBUG=$enableval
-], 
+],
 [
   PHP_APCU_DEBUG=no
 ])
@@ -61,133 +61,133 @@ AC_ARG_ENABLE(apcu-spinlocks,
 AC_MSG_RESULT($PHP_APCU_SPINLOCK)
 
 if test "$PHP_APCU_RWLOCKS" != "no"; then
-	AC_CACHE_CHECK([whether the target compiler supports builtin atomics], PHP_cv_APCU_GCC_ATOMICS, [
+  AC_CACHE_CHECK([whether the target compiler supports builtin atomics], PHP_cv_APCU_GCC_ATOMICS, [
 
-		AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
-				int foo = 0;
-				__sync_add_and_fetch(&foo, 1);
-				__sync_sub_and_fetch(&foo, 1);
-				return 0;
-			]])],[PHP_cv_APCU_GCC_ATOMICS=yes],[PHP_cv_APCU_GCC_ATOMICS=no])
-	])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
+        int foo = 0;
+        __sync_add_and_fetch(&foo, 1);
+        __sync_sub_and_fetch(&foo, 1);
+        return 0;
+      ]])],[PHP_cv_APCU_GCC_ATOMICS=yes],[PHP_cv_APCU_GCC_ATOMICS=no])
+  ])
 
-	if test "x${PHP_cv_APCU_GCC_ATOMICS}" != "xyes"; then
-		AC_MSG_ERROR([Compiler does not support atomics])
-	fi
+  if test "x${PHP_cv_APCU_GCC_ATOMICS}" != "xyes"; then
+    AC_MSG_ERROR([Compiler does not support atomics])
+  fi
 fi
 
 if test "$PHP_APCU" != "no"; then
-	if test "$PHP_APCU_DEBUG" != "no"; then
-		AC_DEFINE(APC_DEBUG, 1, [ ])
-	fi
-  
-	if test "$PHP_APCU_MMAP" != "no"; then
-		AC_DEFINE(APC_MMAP, 1, [ ])
-	fi
+  if test "$PHP_APCU_DEBUG" != "no"; then
+    AC_DEFINE(APC_DEBUG, 1, [ ])
+  fi
+
+  if test "$PHP_APCU_MMAP" != "no"; then
+    AC_DEFINE(APC_MMAP, 1, [ ])
+  fi
 
   if test "$PHP_APCU_RWLOCKS" != "no"; then
-	    orig_LIBS="$LIBS"
-	    LIBS="$LIBS -lpthread"
+      orig_LIBS="$LIBS"
+      LIBS="$LIBS -lpthread"
         AC_MSG_CHECKING([for pthread rwlocks])
-	    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-			    #include <sys/types.h>
-			    #include <pthread.h>
+      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+          #include <sys/types.h>
+          #include <pthread.h>
                 #include <stdio.h>
           int main() {
-			      pthread_rwlock_t rwlock;
-			      pthread_rwlockattr_t attr;	
+            pthread_rwlock_t rwlock;
+            pthread_rwlockattr_t attr;
 
-			      if(pthread_rwlockattr_init(&attr)) { 
-				      puts("Unable to initialize pthread attributes (pthread_rwlockattr_init).");
-				      return -1; 
-			      }
-			      if(pthread_rwlockattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) { 
-				      puts("Unable to set PTHREAD_PROCESS_SHARED (pthread_rwlockattr_setpshared), your system may not support shared rwlock's.");
-				      return -1; 
-			      }	
-			      if(pthread_rwlock_init(&rwlock, &attr)) { 
-				      puts("Unable to initialize the rwlock (pthread_rwlock_init).");
-				      return -1; 
-			      }
-			      if(pthread_rwlockattr_destroy(&attr)) { 
-				      puts("Unable to destroy rwlock attributes (pthread_rwlockattr_destroy).");
-				      return -1; 
-			      }
-			      if(pthread_rwlock_destroy(&rwlock)) { 
-				      puts("Unable to destroy rwlock (pthread_rwlock_destroy).");
-				      return -1; 
-			      }
+            if(pthread_rwlockattr_init(&attr)) {
+              puts("Unable to initialize pthread attributes (pthread_rwlockattr_init).");
+              return -1;
+            }
+            if(pthread_rwlockattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) {
+              puts("Unable to set PTHREAD_PROCESS_SHARED (pthread_rwlockattr_setpshared), your system may not support shared rwlock's.");
+              return -1;
+            }
+            if(pthread_rwlock_init(&rwlock, &attr)) {
+              puts("Unable to initialize the rwlock (pthread_rwlock_init).");
+              return -1;
+            }
+            if(pthread_rwlockattr_destroy(&attr)) {
+              puts("Unable to destroy rwlock attributes (pthread_rwlockattr_destroy).");
+              return -1;
+            }
+            if(pthread_rwlock_destroy(&rwlock)) {
+              puts("Unable to destroy rwlock (pthread_rwlock_destroy).");
+              return -1;
+            }
 
-			      return 0;
+            return 0;
           }
-		    ]])],[ dnl -Success-
-			    APCU_CFLAGS="-D_GNU_SOURCE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
-			    PHP_ADD_LIBRARY(pthread)
-				  PHP_LDFLAGS="$PHP_LDFLAGS -lpthread"
-			    AC_DEFINE(APC_NATIVE_RWLOCK, 1, [ ])
-			    AC_MSG_RESULT([yes])
-		    ],[ dnl -Failure-
-			    AC_MSG_RESULT([no])
-    			PHP_APCU_RWLOCKS=no
-		    ],[
-			    APCU_CFLAGS="-D_GNU_SOURCE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
-			    PHP_ADD_LIBRARY(pthread)
-				  PHP_LDFLAGS="$PHP_LDFLAGS -lpthread"
+        ]])],[ dnl -Success-
+          APCU_CFLAGS="-D_GNU_SOURCE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+          PHP_ADD_LIBRARY(pthread)
+          PHP_LDFLAGS="$PHP_LDFLAGS -lpthread"
+          AC_DEFINE(APC_NATIVE_RWLOCK, 1, [ ])
+          AC_MSG_RESULT([yes])
+        ],[ dnl -Failure-
+          AC_MSG_RESULT([no])
+          PHP_APCU_RWLOCKS=no
+        ],[
+          APCU_CFLAGS="-D_GNU_SOURCE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+          PHP_ADD_LIBRARY(pthread)
+          PHP_LDFLAGS="$PHP_LDFLAGS -lpthread"
     ])
     LIBS="$orig_LIBS"
   fi
-  
+
   if test "$PHP_APCU" != "no"; then
     orig_LIBS="$LIBS"
-	  LIBS="$LIBS -lpthread"
+    LIBS="$LIBS -lpthread"
       AC_MSG_CHECKING([for pthread mutexes])
-	  AC_RUN_IFELSE([AC_LANG_SOURCE([[
-				  #include <sys/types.h>
-				  #include <pthread.h>
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+          #include <sys/types.h>
+          #include <pthread.h>
                   #include <stdio.h>
           int main() {
-				    pthread_mutex_t mutex;
-				    pthread_mutexattr_t attr;	
+            pthread_mutex_t mutex;
+            pthread_mutexattr_t attr;
 
-				    if(pthread_mutexattr_init(&attr)) { 
-					    puts("Unable to initialize pthread attributes (pthread_mutexattr_init).");
-					    return -1; 
-				    }
-				    if(pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) { 
-					    puts("Unable to set PTHREAD_PROCESS_SHARED (pthread_mutexattr_setpshared), your system may not support shared mutex's.");
-					    return -1; 
-				    }	
-				    if(pthread_mutex_init(&mutex, &attr)) { 
-					    puts("Unable to initialize the mutex (pthread_mutex_init).");
-					    return -1; 
-				    }
-				    if(pthread_mutexattr_destroy(&attr)) { 
-					    puts("Unable to destroy mutex attributes (pthread_mutexattr_destroy).");
-					    return -1; 
-				    }
-				    if(pthread_mutex_destroy(&mutex)) { 
-					    puts("Unable to destroy mutex (pthread_mutex_destroy).");
-					    return -1; 
-				    }
-				    return 0;
+            if(pthread_mutexattr_init(&attr)) {
+              puts("Unable to initialize pthread attributes (pthread_mutexattr_init).");
+              return -1;
+            }
+            if(pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) {
+              puts("Unable to set PTHREAD_PROCESS_SHARED (pthread_mutexattr_setpshared), your system may not support shared mutex's.");
+              return -1;
+            }
+            if(pthread_mutex_init(&mutex, &attr)) {
+              puts("Unable to initialize the mutex (pthread_mutex_init).");
+              return -1;
+            }
+            if(pthread_mutexattr_destroy(&attr)) {
+              puts("Unable to destroy mutex attributes (pthread_mutexattr_destroy).");
+              return -1;
+            }
+            if(pthread_mutex_destroy(&mutex)) {
+              puts("Unable to destroy mutex (pthread_mutex_destroy).");
+              return -1;
+            }
+            return 0;
         }
-			  ]])],[ dnl -Success-
-				  APCU_CFLAGS="-D_GNU_SOURCE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
-				  PHP_ADD_LIBRARY(pthread)
-				  PHP_LDFLAGS="$PHP_LDFLAGS -lpthread"
-				  AC_MSG_RESULT([yes])
-				  AC_DEFINE(APC_HAS_PTHREAD_MUTEX, 1, [ ])
-			  ],[ dnl -Failure-
-				  AC_MSG_RESULT([no])
-    			PHP_APCU_MUTEX=no
-			  ],[
-				  APCU_CFLAGS="-D_GNU_SOURCE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
-				  PHP_ADD_LIBRARY(pthread)
-				  PHP_LDFLAGS="$PHP_LDFLAGS -lpthread"
-	  ])
-	  LIBS="$orig_LIBS"
+        ]])],[ dnl -Success-
+          APCU_CFLAGS="-D_GNU_SOURCE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+          PHP_ADD_LIBRARY(pthread)
+          PHP_LDFLAGS="$PHP_LDFLAGS -lpthread"
+          AC_MSG_RESULT([yes])
+          AC_DEFINE(APC_HAS_PTHREAD_MUTEX, 1, [ ])
+        ],[ dnl -Failure-
+          AC_MSG_RESULT([no])
+          PHP_APCU_MUTEX=no
+        ],[
+          APCU_CFLAGS="-D_GNU_SOURCE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+          PHP_ADD_LIBRARY(pthread)
+          PHP_LDFLAGS="$PHP_LDFLAGS -lpthread"
+    ])
+    LIBS="$orig_LIBS"
   fi
-  
+
   if test "$PHP_APCU_RWLOCKS" = "no"; then
    if test "$PHP_APCU_MUTEX" = "no"; then
     if test "$PHP_APCU_SPINLOCK" != "no"; then
@@ -199,7 +199,7 @@ if test "$PHP_APCU" != "no"; then
     fi
    fi
   fi
-	
+
   AC_CHECK_FUNCS(sigaction)
   AC_CACHE_CHECK(for union semun, php_cv_semun,
   [
@@ -226,8 +226,8 @@ if test "$PHP_APCU" != "no"; then
     PHP_APCU_VALGRIND=no
   ], [
     PHP_APCU_VALGRIND=yes
-    AC_CHECK_HEADER(valgrind/memcheck.h, 
-  		[AC_DEFINE([HAVE_VALGRIND_MEMCHECK_H],1, [enable valgrind memchecks])])
+    AC_CHECK_HEADER(valgrind/memcheck.h,
+      [AC_DEFINE([HAVE_VALGRIND_MEMCHECK_H],1, [enable valgrind memchecks])])
   ])
 
   for i in -Wall -Wextra -Wno-unused-parameter; do
@@ -244,7 +244,7 @@ if test "$PHP_APCU" != "no"; then
                  apc_time.c \
                  apc_iterator.c \
                  apc_persist.c"
-							   
+
   PHP_CHECK_LIBRARY(rt, shm_open, [PHP_ADD_LIBRARY(rt,,APCU_SHARED_LIBADD)])
   PHP_NEW_EXTENSION(apcu, $apc_sources, $ext_shared,, \\$(APCU_CFLAGS))
   PHP_SUBST(APCU_SHARED_LIBADD)
@@ -262,7 +262,7 @@ if test "$PHP_COVERAGE" = "yes"; then
   if test "$GCC" != "yes"; then
     AC_MSG_ERROR([GCC is required for --enable-coverage])
   fi
-  
+
   dnl Check if ccache is being used
   case `$php_shtool path $CC` in
     *ccache*[)] gcc_ccache=yes;;
@@ -270,10 +270,10 @@ if test "$PHP_COVERAGE" = "yes"; then
   esac
 
   if test "$gcc_ccache" = "yes" && (test -z "$CCACHE_DISABLE" || test "$CCACHE_DISABLE" != "1"); then
-    AC_MSG_ERROR([ccache must be disabled when --enable-coverage option is used. You can disable ccache by setting environment variable 
+    AC_MSG_ERROR([ccache must be disabled when --enable-coverage option is used. You can disable ccache by setting environment variable
 CCACHE_DISABLE=1.])
   fi
-  
+
   lcov_version_list="1.5 1.6 1.7 1.9"
 
   AC_CHECK_PROG(LCOV, lcov, lcov)
@@ -292,7 +292,7 @@ CCACHE_DISABLE=1.])
       done
     ])
   else
-    lcov_msg="To enable code coverage reporting you must have one of the following LCOV versions installed: $lcov_version_list"      
+    lcov_msg="To enable code coverage reporting you must have one of the following LCOV versions installed: $lcov_version_list"
     AC_MSG_ERROR([$lcov_msg])
   fi
 
@@ -320,4 +320,4 @@ CCACHE_DISABLE=1.])
   CFLAGS="$CFLAGS -O0 -ggdb -fprofile-arcs -ftest-coverage"
   CXXFLAGS="$CXXFLAGS -ggdb -O0 -fprofile-arcs -ftest-coverage"
 fi
-dnl vim: set ts=2 
+dnl vim: set ts=2


### PR DESCRIPTION
https://editorconfig.org/ has integrations with many editors/IDEs to apply project-specific settings (e.g. to consistently use tabs)

https://www.php-fig.org/psr/psr-12/ recommends using spaces for php code. (though many of these tests use tabs, I don't have a strong preference)

Replace the mix of tabs and spaces in config.m4 with spaces.