### PR TITLE
Reduce memory usage of apc.php. Fix division by zero error.

### DIFF
--- a/apc.php
+++ b/apc.php
@@ -183,7 +183,8 @@ if(!function_exists('apcu_cache_info')) {
   exit;
 }
 
-$cache = apcu_cache_info();
+$limited = $MYREQUEST['OB'] != OB_USER_CACHE;
+$cache = apcu_cache_info($limited);
 
 $mem=apcu_sma_info();
 
@@ -758,10 +759,11 @@ case OB_HOST_STATS:
     $mem_avail= $mem['avail_mem'];
     $mem_used = $mem_size-$mem_avail;
     $seg_size = bsize($mem['seg_size']);
-    $req_rate_user = sprintf("%.2f", $cache['num_hits'] ? (($cache['num_hits']+$cache['num_misses'])/($time-$cache['start_time'])) : 0);
-    $hit_rate_user = sprintf("%.2f", $cache['num_hits'] ? (($cache['num_hits'])/($time-$cache['start_time'])) : 0);
-    $miss_rate_user = sprintf("%.2f", $cache['num_misses'] ? (($cache['num_misses'])/($time-$cache['start_time'])) : 0);
-    $insert_rate_user = sprintf("%.2f", $cache['num_inserts'] ? (($cache['num_inserts'])/($time-$cache['start_time'])) : 0);
+    $elapsed = max($time-$cache['start_time'], 1);
+    $req_rate_user = sprintf("%.2f", $cache['num_hits'] ? (($cache['num_hits']+$cache['num_misses'])/$elapsed) : 0);
+    $hit_rate_user = sprintf("%.2f", $cache['num_hits'] ? (($cache['num_hits'])/$elapsed) : 0);
+    $miss_rate_user = sprintf("%.2f", $cache['num_misses'] ? (($cache['num_misses'])/$elapsed) : 0);
+    $insert_rate_user = sprintf("%.2f", $cache['num_inserts'] ? (($cache['num_inserts'])/$elapsed) : 0);
     $apcversion = phpversion('apcu');
     $phpversion = phpversion();
     $number_vars = $cache['num_entries'];


### PR DESCRIPTION
On tabs other than "User Cache Entries", don't fetch metadata about cache entries.

When running php apc.php in CLI to preview this (adding a cached entry),
I noticed a DivisionByZeroError this fixes.

For https://github.com/krakjoe/apcu/issues/365

## Testing

https://www.php.net/manual/en/function.apcu-cache-info.php#refsect1-function.apcu-cache-info-changelog 

I previewed this in cli for convenience by using the environment instead of an http request

`for IMG in {1..3}; do export IMG; php apc.php > $IMG.png; done` - the image generation doesn't use apcu_cache_info.

```diff
--- a/apc.php
+++ b/apc.php
@@ -95,6 +95,10 @@ $scope_list=array(
        'A' => 'cache_list',
        'D' => 'deleted_list'
 );
+$_REQUEST = $_ENV;
+for ($i = 0; $i < 21; $i++) {
+       apcu_store("k$i", str_repeat('x', 2**$i));
+}
 
```