### PR TITLE
use TEST_PHP_ARGS if set

### DIFF
--- a/tests/server_test.inc
+++ b/tests/server_test.inc
@@ -16,6 +16,7 @@ function server_start_one($host, $port, $code = 'echo "Hello world";', $php_opts
 	global $doc_root, $router, $handles, $ports;
 
 	$php_executable = getenv('TEST_PHP_EXECUTABLE');
+	$php_args = getenv('TEST_PHP_ARGS');
 
 	$descriptorspec = array(
 		0 => STDIN,
@@ -23,16 +24,18 @@ function server_start_one($host, $port, $code = 'echo "Hello world";', $php_opts
 		2 => STDERR,
 	);
 
-	$ext = (substr(PHP_OS, 0, 3) == 'WIN') ? 'php_apcu.dll' : 'apcu.so';
-	if (substr(PHP_OS, 0, 3) == 'WIN') {
-		$part0 = 8 == PHP_INT_SIZE ? "x64" : "";
-		$part1 = ZEND_DEBUG_BUILD ? "Debug" : "Release";
-		$part1 = PHP_ZTS ? ($part1 . "_TS") : $part1;
-		$php_args = "-d extension_dir=$doc_root/../$part0/$part1";
-	} else {
-		$php_args = "-d extension_dir=$doc_root/../modules";
+	if (!$php_args) {
+		$ext = (substr(PHP_OS, 0, 3) == 'WIN') ? 'php_apcu.dll' : 'apcu.so';
+		if (substr(PHP_OS, 0, 3) == 'WIN') {
+			$part0 = 8 == PHP_INT_SIZE ? "x64" : "";
+			$part1 = ZEND_DEBUG_BUILD ? "Debug" : "Release";
+			$part1 = PHP_ZTS ? ($part1 . "_TS") : $part1;
+			$php_args = "-d extension_dir=$doc_root/../$part0/$part1";
+		} else {
+			$php_args = "-d extension_dir=$doc_root/../modules";
+		}
+		$php_args = "$php_args -d extension=$ext";
 	}
-	$php_args = "$php_args -d extension=$ext";
 
 	if ($php_opts) {
 		$php_args = "$php_args -d " . implode(' -d ', $php_opts);;


### PR DESCRIPTION
Needed when building out of sources because of `"-d extension_dir=$doc_root/../modules"`

Allow to run:
```
TEST_PHP_ARGS="-n -d extension=$BUILDDIR/modules/apcu.so"  php  run-tests.php --show-diff
```

No change for people building in sources tree and using "make test"