### PR TITLE
feat: improve search pattern validation

### DIFF
--- a/apc.php
+++ b/apc.php
@@ -87,7 +87,7 @@ $vardom=array(
     'SORT1' => '/^[AHSMCDTZ]$/',    // first sort key
     'SORT2' => '/^[DA]$/',          // second sort key
     'AGGR'  => '/^\d+$/',           // aggregation by dir level
-    'SEARCH'    => '~^[a-zA-Z0-9/_.-]*$~'           // aggregation by dir level
+    'SEARCH' => '~^[a-zA-Z0-9/_.\-*\\\]*$~' // search term regex
 );
 
 // cache scope


### PR DESCRIPTION
One should be able to use dash (`-`), wildcard (`*`) and backslash (`\`) in search.

E.g. if a key `myproject.MyNsA\MyNsB\MyClassC-dataMap` exists in cache  I would search `myproject\.MyNsA\\MyNsB.*-dataMap` and get only that specific pattern.