### PR TITLE
LRU Eviction Policy

### DIFF
--- a/apc_cache.h
+++ b/apc_cache.h
@@ -60,6 +60,11 @@ struct apc_cache_entry_t {
 	time_t dtime;            /* time entry was removed from cache */
 	time_t atime;            /* time entry was last accessed */
 	zend_long mem_size;      /* memory used */
+#ifdef APC_LRU
+	/* a circularly doubly linked list used for access history */
+	apc_cache_entry_t *hnext; /* entry with a newer access time than this entry */
+	apc_cache_entry_t *hprev; /* entry with an older access time than this entry */
+#endif
 };
 /* }}} */
 
@@ -77,6 +82,9 @@ typedef struct _apc_cache_header_t {
 	unsigned short state;           /* cache state */
 	apc_cache_slam_key_t lastkey;   /* last key inserted (not necessarily without error) */
 	apc_cache_entry_t *gc;          /* gc list */
+#ifdef APC_LRU
+	apc_cache_entry_t *holdest;     /* oldest entry in the access history */
+#endif
 } apc_cache_header_t; /* }}} */
 
 /* {{{ struct definition: apc_cache_t */

--- a/apc_sma.h
+++ b/apc_sma.h
@@ -142,6 +142,13 @@ PHP_APCU_API size_t apc_sma_get_avail_mem(apc_sma_t* sma);
 */
 PHP_APCU_API zend_bool apc_sma_get_avail_size(apc_sma_t* sma, size_t size);
 
+#ifdef APC_LRU
+/*
+ * apc_sma_check_alloc_size will return true if there is a free block that can store the specified size.
+ */
+PHP_APCU_API zend_bool apc_sma_check_alloc_size(apc_sma_t* sma, size_t size);
+#endif
+
 /*
 * apc_sma_api_check_integrity will check the integrity of sma
 */

--- a/config.m4
+++ b/config.m4
@@ -60,6 +60,17 @@ AC_ARG_ENABLE(apcu-spinlocks,
 ])
 AC_MSG_RESULT($PHP_APCU_SPINLOCK)
 
+AC_MSG_CHECKING(if APCu should utilize LRU eviction policies)
+AC_ARG_ENABLE(apcu-lru,
+[  --enable-apcu-lru  Use LRU eviction policies],
+[
+AC_DEFINE(APC_LRU, 1, [ ])
+AC_MSG_RESULT(yes)
+],
+[
+AC_MSG_RESULT(no)
+])
+
 if test "$PHP_APCU_RWLOCKS" != "no"; then
   AC_CACHE_CHECK([whether the target compiler supports builtin atomics], PHP_cv_APCU_GCC_ATOMICS, [
 

--- a/php_apc.c
+++ b/php_apc.c
@@ -200,6 +200,12 @@ static PHP_MINFO_FUNCTION(apcu)
 		php_info_print_table_row(2, "Serialization Support", "Disabled");
 	}
 
+#if APC_LRU
+	php_info_print_table_row(2, "Eviction Policy", "lru");
+#else
+	php_info_print_table_row(2, "Eviction Policy", "default");
+#endif
+
 	php_info_print_table_row(2, "Build Date", __DATE__ " " __TIME__);
 	php_info_print_table_end();
 	DISPLAY_INI_ENTRIES();

--- a/tests/apc_lru_eviction_policy.phpt
+++ b/tests/apc_lru_eviction_policy.phpt
@@ -1,0 +1,117 @@
+--TEST--
+APC: LRU eviction policy
+--SKIPIF--
+<?php
+require_once(dirname(__FILE__) . '/skipif.inc');
+?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.shm_size=1M
+--FILE--
+<?php
+$cache_info = apcu_cache_info();
+if ($cache_info['eviction_policy'] !== 'lru') {
+    var_dump(true);
+    exit;
+}
+
+$value = str_repeat('X', 300000); // 300KB
+
+$expect = <<<LOG
+A
+A,B
+A,B
+A,B,C
+A,B,C
+A,B,C
+A,D,E
+A,D,E
+A,E,F
+A,E,F
+E,F
+F
+F,G,H
+H,I
+
+A,B,C,D,E,F,G
+A,B,C,D,E,F,G
+A,B,C,D,E,F,G
+A,B,C,D,E,F,G
+A,B,C,D,E,F,G
+A,B,C,D,F,G,H
+A,B,C,D,H,I
+I,J
+
+LOG;
+
+$keylist = '';
+apcu_store('A', $value); // A
+$keylist .= keylist();
+apcu_add('B', $value); // B->A
+$keylist .= keylist();
+apcu_add('A', $value); // B->A (no effect)
+$keylist .= keylist();
+apcu_store('C', $value); // C->B->A
+$keylist .= keylist();
+apcu_fetch('A'); // A->C->B
+$keylist .= keylist();
+apcu_exists('B'); // A->C->B (no effect)
+$keylist .= keylist();
+apcu_store(['D' => $value, 'E' => $value]); // E->D->A
+$keylist .= keylist();
+apcu_entry('A', fn () => $value); // A->E->D
+$keylist .= keylist();
+apcu_entry('F', fn () => $value); // F->A->E
+$keylist .= keylist();
+apcu_fetch(['F', 'A']); // A->F->E
+$keylist .= keylist();
+apcu_delete('A'); // F->E
+$keylist .= keylist();
+apcu_delete('E'); // F
+$keylist .= keylist();
+apcu_store(['G' => $value, 'H' => $value]); // H->G->F
+$keylist .= keylist();
+apcu_store('I', str_repeat($value, 2)); // I->H
+$keylist .= keylist();
+apcu_clear_cache();
+$keylist .= keylist();
+apcu_store([
+    'A' => 1,
+    'B' => 2,
+    'C' => 3,
+    'D' => 4,
+    'E' => $value,
+    'F' => $value,
+    'G' => $value,
+]); // G->F->E->F->C->B->A
+$keylist .= keylist();
+apcu_inc('A'); // A->G->F->E->F->C->B
+$keylist .= keylist();
+apcu_dec('B'); // B->A->G->F->E->F->C
+$keylist .= keylist();
+apcu_cas('C', 3, 5); // C->B->A->G->F->E->F
+$keylist .= keylist();
+apcu_cas('D', 5, 10); // D->C->B->A->G->F->E
+$keylist .= keylist();
+apcu_store('H', $value); // H->D->C->B->A->G->F
+$keylist .= keylist();
+apcu_store('I', str_repeat($value, 2)); // I->H->D->C->B->A
+$keylist .= keylist();
+apcu_store('J', $value); // J->I
+$keylist .= keylist();
+
+var_dump($keylist === $expect);
+
+function keylist(): string
+{
+    $iter = new APCUIterator();
+    $result = [];
+    foreach ($iter as $v) {
+        $result[] = $v['key'];
+    }
+    return implode(',', $result) . PHP_EOL;
+}
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
In this implementation, when `apcu_store`, `apcu_add (only on successful addition)`, `apcu_fetch`, `apcu_entry`, `apcu_inc`, `apcu_dec`, `apcu_cas` are used, the access history is updated.
If the allocation of shared memory fails, the oldest entries in the access history will be deleted.
To enable function, specify `./configure --enable-apcu-lru`.