### PR TITLE
Feature/apcu_set_ttl Add function to set the TTL of an existing entry atomically

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -560,6 +560,7 @@ PHP_APCU_API zend_bool apc_cache_update_ttl(
 		return 0;
 	}
 
+	entry->ctime = t;
 	entry->ttl = ttl;
 
 	apc_cache_runlock(cache);

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -557,7 +557,7 @@ PHP_APCU_API zend_bool apc_cache_update_ttl(
 	entry = apc_cache_rlocked_find_nostat(cache, key, t);
 	if (!entry) {
 		apc_cache_runlock(cache);
-		return 0
+		return 0;
 	}
 
 	entry->ttl = ttl;

--- a/apc_cache.h
+++ b/apc_cache.h
@@ -151,6 +151,13 @@ PHP_APCU_API void apc_cache_clear(apc_cache_t* cache);
 PHP_APCU_API zend_bool apc_cache_store(
         apc_cache_t* cache, zend_string *key, const zval *val,
         const int32_t ttl, const zend_bool exclusive);
+
+/*
+ * apc_cache_update_ttl updates ttl of the key, if it exists
+ */
+PHP_APCU_API zend_bool apc_cache_update_ttl(
+		apc_cache_t* cache, zend_string *key, const int32_t ttl);
+
 /*
  * apc_cache_update updates an entry in place. The updater function must not bailout.
  * The update is performed under write-lock and doesn't have to be atomic.

--- a/php_apc.c
+++ b/php_apc.c
@@ -517,6 +517,30 @@ PHP_FUNCTION(apcu_store) {
 }
 /* }}} */
 
+/* {{{ proto int apcu_ttl(mixed key [, long ttl ])
+ */
+PHP_FUNCTION(apcu_set_ttl) {
+	zval *key;
+	zend_long ttl = 0L;
+	zval *success = NULL;
+	time_t t;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(key)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(ttl)
+	ZEND_PARSE_PARAMETERS_END();
+
+	t = apc_time();
+
+	if (Z_TYPE_P(key) != IS_STRING && Z_TYPE_P(key) != IS_ARRAY) {
+		convert_to_string(key);
+	}
+
+	RETURN_BOOL(apc_cache_update_ttl(apc_user_cache, key, ttl));
+}
+/* }}} */
+
 /* {{{ proto int apcu_add(mixed key, mixed var [, long ttl ])
  */
 PHP_FUNCTION(apcu_add) {

--- a/php_apc.c
+++ b/php_apc.c
@@ -517,10 +517,10 @@ PHP_FUNCTION(apcu_store) {
 }
 /* }}} */
 
-/* {{{ proto int apcu_ttl(mixed key [, long ttl ])
+/* {{{ proto bool apc_cache_update_ttl(mixed key [, long ttl ])
  */
 PHP_FUNCTION(apcu_set_ttl) {
-	zval *key;
+	zend_string *key;
 	zend_long ttl = 0L;
 	zval *success = NULL;
 	time_t t;
@@ -532,10 +532,6 @@ PHP_FUNCTION(apcu_set_ttl) {
 	ZEND_PARSE_PARAMETERS_END();
 
 	t = apc_time();
-
-	if (Z_TYPE_P(key) != IS_STRING && Z_TYPE_P(key) != IS_ARRAY) {
-		convert_to_string(key);
-	}
 
 	RETURN_BOOL(apc_cache_update_ttl(apc_user_cache, key, ttl));
 }

--- a/php_apc.stub.php
+++ b/php_apc.stub.php
@@ -18,6 +18,9 @@ function apcu_enabled(): bool {}
 /** @param array|string $key */
 function apcu_store($key, mixed $value = UNKNOWN, int $ttl = 0): array|bool {}
 
+/** @param string $key */
+function apcu_set_ttl($key, int $ttl = 0): bool {}
+
 /** @param array|string $key */
 function apcu_add($key, mixed $value = UNKNOWN, int $ttl = 0): array|bool {}
 

--- a/php_apc_arginfo.h
+++ b/php_apc_arginfo.h
@@ -24,6 +24,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_apcu_add arginfo_apcu_store
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_apcu_set_ttl, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ttl, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_apcu_inc, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, step, IS_LONG, 0, "1")
@@ -69,6 +74,7 @@ PHP_APCU_API ZEND_FUNCTION(apcu_key_info);
 PHP_APCU_API ZEND_FUNCTION(apcu_sma_info);
 PHP_APCU_API ZEND_FUNCTION(apcu_enabled);
 PHP_APCU_API ZEND_FUNCTION(apcu_store);
+PHP_APCU_API ZEND_FUNCTION(apcu_set_ttl);
 PHP_APCU_API ZEND_FUNCTION(apcu_add);
 PHP_APCU_API ZEND_FUNCTION(apcu_inc);
 PHP_APCU_API ZEND_FUNCTION(apcu_dec);
@@ -89,6 +95,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(apcu_sma_info, arginfo_apcu_sma_info)
 	ZEND_FE(apcu_enabled, arginfo_apcu_enabled)
 	ZEND_FE(apcu_store, arginfo_apcu_store)
+	ZEND_FE(apcu_set_ttl, arginfo_apcu_set_ttl)
 	ZEND_FE(apcu_add, arginfo_apcu_add)
 	ZEND_FE(apcu_inc, arginfo_apcu_inc)
 	ZEND_FE(apcu_dec, arginfo_apcu_dec)


### PR DESCRIPTION
APCu lacks a nice way to update the TTL of an entry. Currently, you'd have to implement your own critical section, fetch the value of an entry, and then store it back. I think there are many use cases with websites where one would want to create a cache entry with a short life and then extend its lifespan on a subsequent request from the browser.

I think this will be especially useful in combination with apcu_inc, apcu_dec, and apcu_cas. Because calling apcu_store (the only way to extend TTL ATM) after them defeats their purpose.

This PR adds `apcu_set_ttl($key, int $ttl = 0): bool`. If entry with the $key has been successfully updated, function returns true, else, false.
