### PR TITLE
tests: Fix PHP ZTS detection

### DIFF
--- a/tests/apc54_014.phpt
+++ b/tests/apc54_014.phpt
@@ -3,7 +3,7 @@ APC: Bug #61742 preload_path does not work due to incorrect string length (varia
 --SKIPIF--
 <?php
 require_once(dirname(__FILE__) . '/skipif.inc');
-if (PHP_ZTS === 1) {
+if (PHP_ZTS) {
     die('skip PHP non-ZTS only');
 }
 ?>

--- a/tests/ghbug176.phpt
+++ b/tests/ghbug176.phpt
@@ -3,7 +3,7 @@ APC: GH Bug #176 preload_path segfaults with bad data
 --SKIPIF--
 <?php
 require_once(dirname(__FILE__) . '/skipif.inc');
-if (PHP_ZTS === 1) {
+if (PHP_ZTS) {
     die('skip PHP non-ZTS only');
 }
 ?>


### PR DESCRIPTION
PHP 8.4 changed the PHP_ZTS constant to bool: https://github.com/php/php-src/pull/13079

As a result, the tests that fail with ZTS would no longer be skipped.
