### PR TITLE
Autotools: Refactor --enable-apcu-rwlocks option to PHP_ARG_ENABLE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -3,18 +3,12 @@ PHP_ARG_ENABLE([apcu],
   [AS_HELP_STRING([--enable-apcu],
     [Enable APCu support])])
 
-AC_MSG_CHECKING(if APCu should be allowed to use rwlocks)
-AC_ARG_ENABLE([apcu-rwlocks],
+PHP_ARG_ENABLE([apcu-rwlocks],
+  [if APCu should be allowed to use rwlocks],
   [AS_HELP_STRING([--disable-apcu-rwlocks],
     [Disable rwlocks in APCu])],
-[
-  PHP_APCU_RWLOCKS=$enableval
-  AC_MSG_RESULT($enableval)
-],
-[
-  PHP_APCU_RWLOCKS=yes
-  AC_MSG_RESULT(yes)
-])
+  [yes],
+  [no])
 
 AC_MSG_CHECKING(if APCu should be built in debug mode)
 AC_ARG_ENABLE([apcu-debug],
@@ -63,23 +57,20 @@ AC_ARG_ENABLE([apcu-spinlocks],
 ])
 AC_MSG_RESULT($PHP_APCU_SPINLOCK)
 
-if test "$PHP_APCU_RWLOCKS" != "no"; then
-  AC_CACHE_CHECK([whether the target compiler supports builtin atomics], PHP_cv_APCU_GCC_ATOMICS, [
-
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
+if test "$PHP_APCU" != "no"; then
+  AS_VAR_IF([PHP_APCU_RWLOCKS], [no], [], [
+    AC_CACHE_CHECK([whether the target compiler supports builtin atomics],
+      [PHP_cv_APCU_GCC_ATOMICS],
+      [AC_LINK_IFELSE([AC_LANG_PROGRAM([], [
         int foo = 0;
         __sync_add_and_fetch(&foo, 1);
         __sync_sub_and_fetch(&foo, 1);
         return 0;
-      ]])],[PHP_cv_APCU_GCC_ATOMICS=yes],[PHP_cv_APCU_GCC_ATOMICS=no])
+      ])], [PHP_cv_APCU_GCC_ATOMICS=yes], [PHP_cv_APCU_GCC_ATOMICS=no])])
+    AS_VAR_IF([PHP_cv_APCU_GCC_ATOMICS], [no],
+      [AC_MSG_FAILURE([Compiler does not support atomics])])
   ])
 
-  if test "x${PHP_cv_APCU_GCC_ATOMICS}" != "xyes"; then
-    AC_MSG_ERROR([Compiler does not support atomics])
-  fi
-fi
-
-if test "$PHP_APCU" != "no"; then
   if test "$PHP_APCU_DEBUG" != "no"; then
     AC_DEFINE(APC_DEBUG, 1, [ ])
   fi


### PR DESCRIPTION
- Instead of AC_ARG_ENABLE the PHP_ARG_ENABLE works in similar manner and outputs the 2nd argument as the check message. Result variable is the same (PHP_APCU_RWLOCKS). By default the option is enabled like before. The 4th argument sets whether the option is enabled, the 5th argument indicates that this is not direct extension related configuration option (build system internal handling stuff).
- AC_CACHE_CHECK check refactored: Entire check moved inside the main "extension-enabled" if block, AS_VAR_IF used, redundant double Autoconf quotes reduced.
- AC_MSG_FAILURE works the same as AC_MSG_ERROR except that it also outputs the "See config.log for details" message at the end in case of failure, directing the user where to check for possible failure reason.