### PR TITLE
Autotools: Sync configure options

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -273,7 +273,7 @@ PHP_APCU_API int APC_UNSERIALIZER_NAME(php) (APC_UNSERIALIZER_ARGS)
 	result = php_var_unserialize(value, &tmp, buf + buf_len, &var_hash);
 	PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
 	BG(serialize_lock)--;
-	
+
 	if (!result) {
 		php_error_docref(NULL, E_NOTICE, "Error at offset %td of %zd bytes", tmp - buf, buf_len);
 		ZVAL_NULL(value);
@@ -1100,7 +1100,7 @@ PHP_APCU_API zend_bool apc_cache_info(zval *info, apc_cache_t *cache, zend_bool 
 		add_assoc_long(info, "start_time", cache->header->stime);
 		array_add_double(info, apc_str_mem_size, (double) cache->header->mem_size);
 
-#if APC_MMAP
+#ifdef APC_MMAP
 		add_assoc_stringl(info, "memory_type", "mmap", sizeof("mmap")-1);
 #else
 		add_assoc_stringl(info, "memory_type", "IPC shared", sizeof("IPC shared")-1);

--- a/apc_globals.h
+++ b/apc_globals.h
@@ -44,7 +44,7 @@ ZEND_BEGIN_MODULE_GLOBALS(apcu)
 	zend_long ttl;               /* parameter to apc_cache_create */
 	zend_long smart;             /* smart value */
 
-#if APC_MMAP
+#ifdef APC_MMAP
 	char *mmap_file_mask;   /* mktemp-style file-mask to pass to mmap */
 #endif
 

--- a/apc_mmap.c
+++ b/apc_mmap.c
@@ -29,7 +29,7 @@
 #include "apc_mmap.h"
 #include "apc_lock.h"
 
-#if APC_MMAP
+#ifdef APC_MMAP
 
 #include <fcntl.h>
 #include <sys/types.h>

--- a/apc_mmap.h
+++ b/apc_mmap.h
@@ -35,7 +35,7 @@
 
 /* Wrapper functions for shared memory mapped files */
 
-#if APC_MMAP
+#ifdef APC_MMAP
 apc_segment_t apc_mmap(char *file_mask, size_t size);
 void apc_unmap(apc_segment_t* segment);
 #endif

--- a/apc_sma.c
+++ b/apc_sma.c
@@ -299,7 +299,7 @@ PHP_APCU_API void apc_sma_init(apc_sma_t* sma, void** data, apc_sma_expunge_f ex
 	sma->expunge = expunge;
 	sma->data = data;
 
-#if APC_MMAP
+#ifdef APC_MMAP
 	/*
 	 * I don't think multiple anonymous mmaps makes any sense
 	 * so force sma_numseg to 1 in this case
@@ -324,7 +324,7 @@ PHP_APCU_API void apc_sma_init(apc_sma_t* sma, void** data, apc_sma_expunge_f ex
 		block_t     *first, *empty, *last;
 		void*       shmaddr;
 
-#if APC_MMAP
+#ifdef APC_MMAP
 		sma->segs[i] = apc_mmap(mask, sma->size);
 		if(sma->num != 1)
 			memcpy(&mask[strlen(mask)-6], "XXXXXX", 6);
@@ -388,7 +388,7 @@ PHP_APCU_API void apc_sma_detach(apc_sma_t* sma) {
 	sma->initialized = 0;
 
 	for (i = 0; i < sma->num; i++) {
-#if APC_MMAP
+#ifdef APC_MMAP
 		apc_unmap(&sma->segs[i]);
 #else
 		apc_shm_detach(&sma->segs[i]);

--- a/php_apc.c
+++ b/php_apc.c
@@ -94,7 +94,7 @@ static void php_apc_init_globals(zend_apcu_globals* apcu_globals)
 static PHP_INI_MH(OnUpdateShmSegments) /* {{{ */
 {
 	zend_long shm_segments = ZEND_STRTOL(new_value->val, NULL, 10);
-#if APC_MMAP
+#ifdef APC_MMAP
 	if (shm_segments != 1) {
 		php_error_docref(NULL, E_WARNING, "apc.shm_segments setting ignored in MMAP mode");
 	}
@@ -139,7 +139,7 @@ STD_PHP_INI_ENTRY("apc.entries_hint",   "4096", PHP_INI_SYSTEM, OnUpdateLong,   
 STD_PHP_INI_ENTRY("apc.gc_ttl",         "3600", PHP_INI_SYSTEM, OnUpdateLong,              gc_ttl,           zend_apcu_globals, apcu_globals)
 STD_PHP_INI_ENTRY("apc.ttl",            "0",    PHP_INI_SYSTEM, OnUpdateLong,              ttl,              zend_apcu_globals, apcu_globals)
 STD_PHP_INI_ENTRY("apc.smart",          "0",    PHP_INI_SYSTEM, OnUpdateLong,              smart,            zend_apcu_globals, apcu_globals)
-#if APC_MMAP
+#ifdef APC_MMAP
 STD_PHP_INI_ENTRY("apc.mmap_file_mask",  NULL,  PHP_INI_SYSTEM, OnUpdateString,            mmap_file_mask,   zend_apcu_globals, apcu_globals)
 #endif
 STD_PHP_INI_BOOLEAN("apc.enable_cli",   "0",    PHP_INI_SYSTEM, OnUpdateBool,              enable_cli,       zend_apcu_globals, apcu_globals)
@@ -168,7 +168,7 @@ static PHP_MINFO_FUNCTION(apcu)
 #else
 	php_info_print_table_row(2, "APCu Debugging", "Disabled");
 #endif
-#if APC_MMAP
+#ifdef APC_MMAP
 	php_info_print_table_row(2, "MMAP Support", "Enabled");
 	php_info_print_table_row(2, "MMAP File Mask", APCG(mmap_file_mask));
 #else
@@ -235,7 +235,7 @@ static PHP_MINIT_FUNCTION(apcu)
 	if (APCG(enabled)) {
 
 		if (!APCG(initialized)) {
-#if APC_MMAP
+#ifdef APC_MMAP
 			char *mmap_file_mask = APCG(mmap_file_mask);
 #else
 			char *mmap_file_mask = NULL;


### PR DESCRIPTION
- AC_ARG_ENABLE replaced with PHP_ARG_ENABLE
- checks sorted
- AS_VAR_IF macros used
- For checking the Valgrind header, the AC_CHECK_HEADERS is used which defines the HAVE_VALGRIND_MEMCHECK_H preprocessor macro by default
- The APC_MMAP preprocessor macro is either undefined or defined to 1 so the `#if` checks are also replaced with `#ifdef` to not cause possible -Wundef warnings emitted if such compiler configuration is set