### PR TITLE
Fix -Wundef warnings

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -273,7 +273,7 @@ PHP_APCU_API int APC_UNSERIALIZER_NAME(php) (APC_UNSERIALIZER_ARGS)
 	result = php_var_unserialize(value, &tmp, buf + buf_len, &var_hash);
 	PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
 	BG(serialize_lock)--;
-	
+
 	if (!result) {
 		php_error_docref(NULL, E_NOTICE, "Error at offset %td of %zd bytes", tmp - buf, buf_len);
 		ZVAL_NULL(value);
@@ -1210,7 +1210,7 @@ PHP_APCU_API zend_bool apc_cache_defense(apc_cache_t *cache, zend_string *key, t
 			last->len == ZSTR_LEN(key) &&
 			last->mtime == t &&
 			(last->owner_pid != owner_pid
-#if ZTS
+#ifdef ZTS
 			 || last->owner_thread != owner_thread
 #endif
 			)

--- a/apc_signal.c
+++ b/apc_signal.c
@@ -34,7 +34,7 @@
 
 #include "apc.h"
 
-#if HAVE_SIGACTION
+#ifdef HAVE_SIGACTION
 #include <signal.h>
 #include "apc_globals.h"
 #include "apc_sma.h"

--- a/apc_sma.c
+++ b/apc_sma.c
@@ -331,7 +331,7 @@ PHP_APCU_API void apc_sma_init(apc_sma_t* sma, void** data, apc_sma_expunge_f ex
 #else
 		{
 			int j = apc_shm_create(i, sma->size);
-#if PHP_WIN32
+#ifdef PHP_WIN32
 			/* TODO remove the line below after 7.1 EOL. */
 			SetLastError(0);
 #endif

--- a/php_apc.c
+++ b/php_apc.c
@@ -58,7 +58,7 @@
 #include "SAPI.h"
 #include "php_apc.h"
 
-#if HAVE_SIGACTION
+#ifdef HAVE_SIGACTION
 #include "apc_signal.h"
 #endif
 
@@ -300,7 +300,7 @@ static PHP_MSHUTDOWN_FUNCTION(apcu)
 			APCG(initialized) = 0;
 		}
 
-#if HAVE_SIGACTION
+#ifdef HAVE_SIGACTION
 		apc_shutdown_signals();
 #endif
 	}
@@ -325,7 +325,7 @@ static PHP_RINIT_FUNCTION(apcu)
 			apc_cache_serializer(apc_user_cache, APCG(serializer_name));
 		}
 
-#if HAVE_SIGACTION
+#ifdef HAVE_SIGACTION
 		apc_set_signals();
 #endif
 	}


### PR DESCRIPTION
- ZTS
- PHP_WIN32
- HAVE_SIGACTION

are either undefined or defined to 1. This fixes possible -Wundef (Windows C4668 warning code) warnings if such compiler configuration is set.