### PR TITLE
Autotools: Refactor rt library check

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -221,7 +221,7 @@ if test "$PHP_APCU" != "no"; then
   AC_SEARCH_LIBS([shm_open], [rt])
   LIBS=$LIBS_SAVED
   AS_CASE([$ac_cv_search_shm_open], ["none required"|no], [],
-    [PHP_ADD_LIBRARY([rt], [], [APCU_SHARED_LIBADD])])
+    [PHP_EVAL_LIBLINE([$ac_cv_search_shm_open], [APCU_SHARED_LIBADD])])
 
   PHP_NEW_EXTENSION([apcu], [$apc_sources], [$ext_shared],, [$APCU_CFLAGS])
   PHP_SUBST(APCU_SHARED_LIBADD)

--- a/config.m4
+++ b/config.m4
@@ -217,7 +217,12 @@ if test "$PHP_APCU" != "no"; then
                  apc_iterator.c \
                  apc_persist.c"
 
-  PHP_CHECK_LIBRARY(rt, shm_open, [PHP_ADD_LIBRARY(rt,,APCU_SHARED_LIBADD)])
+  LIBS_SAVED=$LIBS; LIBS=
+  AC_SEARCH_LIBS([shm_open], [rt])
+  LIBS=$LIBS_SAVED
+  AS_VAR_IF([ac_cv_search_shm_open], ["none required"], [],
+    [PHP_ADD_LIBRARY([rt], [], [APCU_SHARED_LIBADD])])
+
   PHP_NEW_EXTENSION([apcu], [$apc_sources], [$ext_shared],, [$APCU_CFLAGS])
   PHP_SUBST(APCU_SHARED_LIBADD)
   PHP_SUBST(PHP_LDFLAGS)

--- a/config.m4
+++ b/config.m4
@@ -220,7 +220,7 @@ if test "$PHP_APCU" != "no"; then
   LIBS_SAVED=$LIBS; LIBS=
   AC_SEARCH_LIBS([shm_open], [rt])
   LIBS=$LIBS_SAVED
-  AS_VAR_IF([ac_cv_search_shm_open], ["none required"], [],
+  AS_CASE([$ac_cv_search_shm_open], ["none required"|no], [],
     [PHP_ADD_LIBRARY([rt], [], [APCU_SHARED_LIBADD])])
 
   PHP_NEW_EXTENSION([apcu], [$apc_sources], [$ext_shared],, [$APCU_CFLAGS])


### PR DESCRIPTION
This appends the -lrt only as needed to the LIBS (if apcu is built as static) or to the APCU_SHARED_LIBADD variable (when APCu is built as shared). Modern *nix systems have shared memory operations located in default libraries and explicit linking with -lrt is redundant.

~Edit: fixing this for the case when shm_open isn't found...~