### PR TITLE
Run Windows CI against PHP 8.4, too

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -31,11 +31,12 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-        version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
         arch: [x64]
         ts: [nts, ts]
         os: [windows-2019, windows-2022]
         exclude:
+          - { os: windows-2019, version: "8.4" }
           - { os: windows-2019, version: "8.3" }
           - { os: windows-2019, version: "8.2" }
           - { os: windows-2019, version: "8.1" }
@@ -49,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup PHP
         id: setup-php
-        uses: php/setup-php-sdk@1248285eaa27e8fe99a03ad2108cf062669ac3f4
+        uses: php/setup-php-sdk@8d9e79bdbce494591e33d542377778613cfca59f
         with:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}


### PR DESCRIPTION
We also change the setup-php-sdk branch to a commit on the main branch. This should be changed again when a new setup-php-sdk release is made.