### PR TITLE
Fix Windows CI artifact upload

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -69,17 +69,17 @@ jobs:
         run: nmake test TESTS="--show-diff tests"
       - name: package
         run: |
-          md .install
-          copy LICENSE .install
+          md win-install
+          copy LICENSE win-install
           if exist x64 (
             if exist x64\Release (set prefix=x64\Release) else set prefix=x64\Release_TS
           ) else (
             if exist Release (set prefix=Release) else set prefix=Release_TS
           )
-          copy %prefix%\php_apcu.dll .install
-          copy %prefix%\php_apcu.pdb .install
+          copy %prefix%\php_apcu.dll win-install
+          copy %prefix%\php_apcu.pdb win-install
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: apcu-${{matrix.version}}-${{matrix.arch}}-${{matrix.ts}}
-          path: .install
+          path: win-install


### PR DESCRIPTION
As of actions/upload-artifact@v4, hidden files are excluded from uploading by default, so the `.install` folder is no longer uploaded. Instead of changing the default, we change the name of the folder to `win-install` which generally appears to make more sense than a hidden folder.