### PR TITLE
Fix apc_sma_get_avail_size() to look for a contiguous block of memory to make expunge more reliable

### DIFF
--- a/apc_sma.h
+++ b/apc_sma.h
@@ -138,7 +138,7 @@ PHP_APCU_API void apc_sma_free_info(apc_sma_t* sma, apc_sma_info_t* info);
 PHP_APCU_API size_t apc_sma_get_avail_mem(apc_sma_t* sma);
 
 /*
-* apc_sma_api_get_avail_size will return true if at least size bytes are available to the sma
+* apc_sma_api_get_avail_size will return true if at least size contiguous bytes are available to the sma
 */
 PHP_APCU_API zend_bool apc_sma_get_avail_size(apc_sma_t* sma, size_t size);
 

--- a/tests/apc_020.phpt
+++ b/tests/apc_020.phpt
@@ -17,7 +17,7 @@ apc.shm_size=1M
 apcu_store("no_ttl_unaccessed", 12);
 apcu_store("no_ttl_accessed", 24);
 apcu_store("ttl", 42, 3);
-apcu_store("dummy", "xxx");
+apcu_store("dummy", str_repeat('x', 1000));
 
 apcu_inc_request_time(1);
 apcu_fetch("no_ttl_accessed");


### PR DESCRIPTION
apc_sma_get_avail_size() is used by apc_cache_default_expunge() to check whether enough memory is available to store a new cache entry after expired entries are removed. If there is not enough memory available, a real expunge is performed to be able to store the new entry.

The problem is that apc_sma_get_avail_size() only checks the total amount of available memory, which is usually divided into several fragments of memory. However, we need a contiguous block of memory to store a cache entry.

This pull request fixes apc_sma_get_avail_size() to check if a continuous block of memory is available to store a new entry, which solves the problem.

Prior to this fix, the result was that in situations with fragmentation, new cache entries cannot be saved and PHP functions such as apcu_store() return false, which is not the expected behavior.
