### PR TITLE
config.m4: Add -Wno-clobbered to fix compiler warnings

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -201,7 +201,7 @@ if test "$PHP_APCU" != "no"; then
 
   AC_CHECK_FUNCS(sigaction)
 
-  for i in -Wall -Wextra -Wno-unused-parameter; do
+  for i in -Wall -Wextra -Wno-clobbered -Wno-unused-parameter; do
     AX_CHECK_COMPILE_FLAG([$i], [APCU_CFLAGS="$APCU_CFLAGS $i"])
   done
 


### PR DESCRIPTION
This fixes compiler warnings in out-of-tree builds.

Closes #521 