### PR TITLE
Change behavior of smart configuration setting

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -753,11 +753,9 @@ PHP_APCU_API void apc_cache_default_expunge(apc_cache_t* cache, size_t size)
 	/* gc */
 	apc_cache_wlocked_gc(cache);
 
-	/* check that expunge is necessary */
-	if (cache->smart > 0L && apc_sma_get_avail_mem(cache->sma) >= (size_t) (cache->smart * size)) {
-		apc_cache_wunlock(cache);
-		return;
-	}
+	/* smart > 1 increases the probability of a full cache wipe,
+	 * so expunge() is called less often when memory is low. */
+	size = (cache->smart > 0L) ? (size_t) (cache->smart * size) : size;
 
 	/* look for junk */
 	for (i = 0; i < cache->nslots; i++) {

--- a/apc_cache.h
+++ b/apc_cache.h
@@ -251,20 +251,12 @@ PHP_APCU_API void apc_cache_serializer(apc_cache_t* cache, const char* name);
 
 /* {{{ apc_cache_default_expunge
 * Where smart is not set:
-*  Where no ttl is set on cache:
-*   1) Perform cleanup of stale entries
-*   2) Expunge if available memory is less than sma->size/2
-*  Where ttl is set on cache:
-*   1) Perform cleanup of stale entries
-*   2) If available memory if less than the size requested, run full expunge
+*  1) Perform cleanup of stale entries
+*  2) If available memory is less than the size requested, run full expunge
 *
 * Where smart is set:
-*  Where no ttl is set on cache:
-*   1) Perform cleanup of stale entries
-*   2) Expunge is available memory is less than size * smart
-*  Where ttl is set on cache:
-*   1) Perform cleanup of stale entries
-*   2) If available memory if less than the size requested, run full expunge
+*  1) Perform cleanup of stale entries
+*  2) If available memory is less than the size requested * smart, run full expunge
 *
 * The TTL of an entry takes precedence over the TTL of a cache
 */


### PR DESCRIPTION
The smart configuration setting can now be used to increase the chance of full cache wipes during periods of high memory pressure. The idea is to use smart values > 1 to avoid performance problems when the expunge() hook is executed too often. The previous behavior was changed because it could unpredictably cause the insertion of new cache entries to fail, making the smart setting nearly useless.