### PR TITLE
Fix computation of minimum fragment size

### DIFF
--- a/apc_cache.h
+++ b/apc_cache.h
@@ -299,6 +299,8 @@ static inline void apc_cache_runlock(apc_cache_t *cache) {
 	}
 }
 
+#define APC_ENTRY_MIN_ALLOC_SIZE (ZEND_MM_ALIGNED_SIZE(sizeof(apc_cache_entry_t)) + ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(1)))
+
 #endif
 
 /*

--- a/apc_sma.h
+++ b/apc_sma.h
@@ -76,6 +76,7 @@ typedef struct _apc_sma_t {
 	int32_t  num;                  /* number of segments */
 	size_t size;                   /* segment size */
 	int32_t  last;                 /* last segment */
+	size_t min_block_size;         /* expected minimum size of allocated blocks */
 
 	/* segments */
 	apc_segment_t *segs;           /* segments */
@@ -88,7 +89,7 @@ typedef struct _apc_sma_t {
 */
 PHP_APCU_API void apc_sma_init(
 		apc_sma_t* sma, void** data, apc_sma_expunge_f expunge,
-		int32_t num, size_t size, char *mask);
+		int32_t num, size_t size, size_t min_alloc_size, char *mask);
 
 /*
  * apc_sma_detach will detach from shared memory and cleanup local allocations.

--- a/php_apc.c
+++ b/php_apc.c
@@ -247,7 +247,7 @@ static PHP_MINIT_FUNCTION(apcu)
 			/* initialize shared memory allocator */
 			apc_sma_init(
 				&apc_sma, (void **) &apc_user_cache, (apc_sma_expunge_f) apc_cache_default_expunge,
-				APCG(shm_segments), APCG(shm_size), mmap_file_mask);
+				APCG(shm_segments), APCG(shm_size), APC_ENTRY_MIN_ALLOC_SIZE, mmap_file_mask);
 
 			REGISTER_LONG_CONSTANT(APC_SERIALIZER_CONSTANT, (zend_long)&_apc_register_serializer, CONST_PERSISTENT | CONST_CS);
 


### PR DESCRIPTION
The minimum fragment size previously used by the sma layer was too small. This could lead to the unnecessary creation of small free blocks that could not be used for any allocation. To keep separation of layers, the minimum size is now passed to apc_sma_init().