### PR TITLE
Remove unnecessary variables from apc_cache_t and apc_cache_header_t

### DIFF
--- a/TECHNOTES.txt
+++ b/TECHNOTES.txt
@@ -148,7 +148,6 @@ form of a quick-start guide to start hacking on APCu.
 
     /* {{{ struct definition: apc_cache_t */
     typedef struct _apc_cache_t {
-        void* shmaddr;                /* process (local) address of shared cache */
         apc_cache_header_t* header;   /* cache header (stored in SHM) */
         apc_cache_entry_t** slots;    /* array of cache slots (stored in SHM) */
         apc_sma_t* sma;               /* shared memory allocator */
@@ -176,7 +175,6 @@ form of a quick-start guide to start hacking on APCu.
         zend_long nentries;              /* entry count */
         zend_long mem_size;              /* used */
         time_t stime;                    /* start time */
-        unsigned short state;            /* cache state */
         apc_cache_slam_key_t lastkey;    /* last key inserted (not necessarily without error) */
         apc_cache_entry_t *gc;           /* gc list */
     } apc_cache_header_t; /* }}} */

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -295,32 +295,29 @@ PHP_APCU_API apc_cache_t* apc_cache_create(apc_sma_t* sma, apc_serializer_t* ser
 	cache = pemalloc(sizeof(apc_cache_t), 1);
 
 	/* calculate cache size for shm allocation */
-	cache_size = sizeof(apc_cache_header_t) + nslots*sizeof(apc_cache_entry_t *);
+	cache_size = sizeof(apc_cache_header_t) + nslots * sizeof(apc_cache_entry_t *);
 
 	/* allocate shm */
-	cache->shmaddr = apc_sma_malloc(sma, cache_size);
+	cache->header = apc_sma_malloc(sma, cache_size);
 
-	if (!cache->shmaddr) {
+	if (!cache->header) {
 		zend_error_noreturn(E_CORE_ERROR, "Unable to allocate " ZEND_LONG_FMT " bytes of shared memory for cache structures. Either apc.shm_size is too small or apc.entries_hint too large", cache_size);
 		return NULL;
 	}
 
 	/* zero cache header and hash slots */
-	memset(cache->shmaddr, 0, cache_size);
+	memset(cache->header, 0, cache_size);
 
-	/* set default header */
-	cache->header = (apc_cache_header_t*) cache->shmaddr;
-
+	/* set header values */
 	cache->header->nhits = 0;
 	cache->header->nmisses = 0;
 	cache->header->nentries = 0;
 	cache->header->nexpunges = 0;
 	cache->header->gc = NULL;
 	cache->header->stime = time(NULL);
-	cache->header->state = 0;
 
 	/* set cache options */
-	cache->slots = (apc_cache_entry_t **) (((char*) cache->shmaddr) + sizeof(apc_cache_header_t));
+	cache->slots = (apc_cache_entry_t **) (((char*) cache->header) + sizeof(apc_cache_header_t));
 	cache->sma = sma;
 	cache->serializer = serializer;
 	cache->nslots = nslots;

--- a/apc_cache.h
+++ b/apc_cache.h
@@ -74,22 +74,20 @@ typedef struct _apc_cache_header_t {
 	zend_long nentries;             /* entry count */
 	zend_long mem_size;             /* used */
 	time_t stime;                   /* start time */
-	unsigned short state;           /* cache state */
 	apc_cache_slam_key_t lastkey;   /* last key inserted (not necessarily without error) */
 	apc_cache_entry_t *gc;          /* gc list */
 } apc_cache_header_t; /* }}} */
 
 /* {{{ struct definition: apc_cache_t */
 typedef struct _apc_cache_t {
-	void* shmaddr;                /* process (local) address of shared cache */
 	apc_cache_header_t* header;   /* cache header (stored in SHM) */
 	apc_cache_entry_t** slots;    /* array of cache slots (stored in SHM) */
 	apc_sma_t* sma;               /* shared memory allocator */
 	apc_serializer_t* serializer; /* serializer */
 	size_t nslots;                /* number of slots in cache */
-	zend_long gc_ttl;            /* maximum time on GC list for a entry */
-	zend_long ttl;               /* if slot is needed and entry's access time is older than this ttl, remove it */
-	zend_long smart;             /* smart parameter for gc */
+	zend_long gc_ttl;             /* maximum time on GC list for a entry */
+	zend_long ttl;                /* if slot is needed and entry's access time is older than this ttl, remove it */
+	zend_long smart;              /* smart parameter for gc */
 	zend_bool defend;             /* defense parameter for runtime */
 } apc_cache_t; /* }}} */
 


### PR DESCRIPTION
The "state" variable was unused and shmaddr pointed to the same address as header.