### PR TITLE
Fix size of initial empty block in sma layer

### DIFF
--- a/apc_sma.c
+++ b/apc_sma.c
@@ -310,7 +310,7 @@ PHP_APCU_API void apc_sma_init(apc_sma_t* sma, void** data, apc_sma_expunge_f ex
 		SET_CANARY(first);
 
 		empty = BLOCKAT(first->fnext);
-		empty->size = smaheader->avail - ALIGNWORD(sizeof(block_t));
+		empty->size = smaheader->avail;
 		empty->fnext = OFFSET(empty) + empty->size;
 		empty->fprev = ALIGNWORD(sizeof(sma_header_t));
 		empty->prev_size = 0;


### PR DESCRIPTION
The sum of the size of all free blocks is now in sync with smaheader->avail. Additionally, this fixes the position of the last (0-sized) block. Before this change, ALIGNWORD(sizeof(block_t)) bytes remained free at the end of the shared memory.