### PR TITLE
Optimize ALIGNWORD()

### DIFF
--- a/apc_sma.h
+++ b/apc_sma.h
@@ -129,9 +129,7 @@ PHP_APCU_API zend_bool apc_sma_get_avail_size(apc_sma_t* sma, size_t size);
 PHP_APCU_API void apc_sma_check_integrity(apc_sma_t* sma); /* }}} */
 
 /* {{{ ALIGNWORD: pad up x, aligned to the system's word boundary */
-typedef union { void* p; int i; long l; double d; void (*f)(void); } apc_word_t;
-#define ALIGNSIZE(x, size) ((size) * (1 + (((x)-1)/(size))))
-#define ALIGNWORD(x) ALIGNSIZE(x, sizeof(apc_word_t))
+#define ALIGNWORD(x) ZEND_MM_ALIGNED_SIZE(x)
 /* }}} */
 
 #endif


### PR DESCRIPTION
ALIGNWORD() now redefines ZEND_MM_ALIGNED_SIZE(), which PHP itself uses to align data structures. It's better optimized and allows the compiler to generate faster code. It also makes sense to use the same alignment in APCU as in PHP.