### PR TITLE
Use mtime instead of ctime for hard expiration checks

### DIFF
--- a/TECHNOTES.txt
+++ b/TECHNOTES.txt
@@ -265,7 +265,7 @@ form of a quick-start guide to start hacking on APCu.
         zend_long ref_count;     /* the reference count of this entry */
         zend_long nhits;         /* number of hits to this entry */
         time_t ctime;            /* time entry was initialized */
-        time_t mtime;            /* the mtime of this cached entry */
+        time_t mtime;            /* time entry was last modified */
         time_t dtime;            /* time entry was removed from cache */
         time_t atime;            /* time entry was last accessed */
         zend_long mem_size;      /* memory used */

--- a/apc_cache.h
+++ b/apc_cache.h
@@ -39,7 +39,7 @@ typedef struct apc_cache_slam_key_t apc_cache_slam_key_t;
 struct apc_cache_slam_key_t {
 	zend_ulong hash;         /* hash of the key */
 	size_t len;              /* length of the key */
-	time_t mtime;            /* creation time of this key */
+	time_t ctime;            /* creation time of this key */
 	pid_t owner_pid;         /* the pid that created this key */
 #ifdef ZTS
 	void ***owner_thread;    /* TSRMLS cache of thread that created this key */
@@ -56,7 +56,7 @@ struct apc_cache_entry_t {
 	zend_long ref_count;     /* the reference count of this entry */
 	zend_long nhits;         /* number of hits to this entry */
 	time_t ctime;            /* time entry was initialized */
-	time_t mtime;            /* the mtime of this cached entry */
+	time_t mtime;            /* time entry was last modified */
 	time_t dtime;            /* time entry was removed from cache */
 	time_t atime;            /* time entry was last accessed */
 	zend_long mem_size;      /* memory used */

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -199,10 +199,8 @@ static int apc_iterator_search_match(apc_iterator_t *iterator, apc_cache_entry_t
 /* {{{ apc_iterator_check_expiry */
 static int apc_iterator_check_expiry(apc_cache_t* cache, apc_cache_entry_t *entry, time_t t)
 {
-	if (entry->ttl) {
-		if ((time_t) (entry->ctime + entry->ttl) < t) {
-			return 0;
-		}
+	if (entry->ttl && (time_t) (entry->mtime + entry->ttl) < t) {
+		return 0;
 	}
 
 	return 1;

--- a/tests/apc_021.phpt
+++ b/tests/apc_021.phpt
@@ -13,8 +13,8 @@ apc.ttl=1
 --FILE--
 <?php
 
-apcu_store("inc", 0, 3);
-apcu_store("dec", 0, 3);
+apcu_store("inc", 0, 2);
+apcu_store("dec", 0, 2);
 
 echo "T+0:\n";
 
@@ -31,8 +31,8 @@ var_dump(apcu_fetch("inc"));
 var_dump(apcu_dec("dec"));
 var_dump(apcu_fetch("dec"));
 
-apcu_inc_request_time(2);
-echo "T+4\n";
+apcu_inc_request_time(3);
+echo "T+5:\n";
 
 var_dump(apcu_inc("inc"));
 var_dump(apcu_fetch("inc"));
@@ -51,7 +51,7 @@ int(2)
 int(2)
 int(-2)
 int(-2)
-T+4
+T+5:
 int(1)
 int(1)
 int(-1)

--- a/tests/apc_022.phpt
+++ b/tests/apc_022.phpt
@@ -13,34 +13,60 @@ apc.ttl=0
 --FILE--
 <?php
 
-$ttl = 1;
-apcu_store("a", 0, $ttl);
-apcu_store("b", 0, $ttl);
+echo "T+0:\n";
 
-for ($i = 0; $i < 6; $i++) {
-    echo "T+$i:\n";
-    var_dump(apcu_inc("a"));
-    var_dump(apcu_inc("b", 1, $success, $ttl));
-    apcu_inc_request_time(1);
-}
+/* insert new entry with ttl 1 */
+var_dump(apcu_inc("a", 1, $success, 1));
+
+apcu_inc_request_time(1);
+echo "T+1:\n";
+
+/* old entry still exists -> ttl is not updated */
+var_dump(apcu_inc("a", 1, $success, 2));
+
+apcu_inc_request_time(2);
+echo "T+3:\n";
+
+/* old entry is expired -> insert new entry with ttl 2 */
+var_dump(apcu_inc("a", 1, $success, 2));
+
+apcu_inc_request_time(2);
+echo "T+5:\n";
+
+/* old entry still exists -> ttl is not updated */
+var_dump(apcu_inc("a", 1, $success, 3));
+
+apcu_inc_request_time(3);
+echo "T+8:\n";
+
+/* old entry is expired -> insert new entry with ttl 0 */
+var_dump(apcu_inc("a"));
+
+apcu_inc_request_time(4);
+echo "T+12:\n";
+
+/* old entry still exists -> ttl is not updated */
+var_dump(apcu_inc("a", 1, $success, 1));
+
+apcu_inc_request_time(3);
+echo "T+15:\n";
+
+/* old entry still exists -> ttl is not updated */
+var_dump(apcu_inc("a", 1, $success, 1));
 
 ?>
 --EXPECT--
 T+0:
 int(1)
-int(1)
 T+1:
 int(2)
-int(2)
-T+2:
-int(1)
-int(1)
 T+3:
-int(2)
-int(2)
-T+4:
-int(3)
 int(1)
 T+5:
-int(4)
 int(2)
+T+8:
+int(1)
+T+12:
+int(2)
+T+15:
+int(3)


### PR DESCRIPTION
Using mtime instead of ctime for expiration checks causes an entry's TTL timer to restart when the entry is changed. This prevents entries from expiring shortly after a change, which makes no sense.