### PR TITLE
Make the key of a cache entry relocatable

### DIFF
--- a/TECHNOTES.txt
+++ b/TECHNOTES.txt
@@ -258,7 +258,6 @@ form of a quick-start guide to start hacking on APCu.
     /* {{{ struct definition: apc_cache_entry_t */
     typedef struct apc_cache_entry_t apc_cache_entry_t;
     struct apc_cache_entry_t {
-        zend_string *key;        /* entry key */
         zval val;                /* the zval copied at store time */
         apc_cache_entry_t *next; /* next entry in linked list */
         zend_long ttl;           /* the ttl on this specific entry */
@@ -269,6 +268,7 @@ form of a quick-start guide to start hacking on APCu.
         time_t dtime;            /* time entry was removed from cache */
         time_t atime;            /* time entry was last accessed */
         zend_long mem_size;      /* memory used */
+        zend_string key;         /* entry key (MUST BE THE LAST FIELD OF THE STRUCT!) */
     };
     /* }}} */
 

--- a/apc_cache.h
+++ b/apc_cache.h
@@ -49,7 +49,6 @@ struct apc_cache_slam_key_t {
 /* {{{ struct definition: apc_cache_entry_t */
 typedef struct apc_cache_entry_t apc_cache_entry_t;
 struct apc_cache_entry_t {
-	zend_string *key;        /* entry key */
 	zval val;                /* the zval copied at store time */
 	apc_cache_entry_t *next; /* next entry in linked list */
 	zend_long ttl;           /* the ttl on this specific entry */
@@ -60,6 +59,7 @@ struct apc_cache_entry_t {
 	time_t dtime;            /* time entry was removed from cache */
 	time_t atime;            /* time entry was last accessed */
 	zend_long mem_size;      /* memory used */
+	zend_string key;         /* entry key (MUST BE THE LAST FIELD OF THE STRUCT!) */
 };
 /* }}} */
 
@@ -297,7 +297,8 @@ static inline void apc_cache_runlock(apc_cache_t *cache) {
 	}
 }
 
-#define APC_ENTRY_MIN_ALLOC_SIZE (ZEND_MM_ALIGNED_SIZE(sizeof(apc_cache_entry_t)) + ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(1)))
+/* APC_ENTRY_SIZE takes into account the trailing key-string + terminating 0-byte */
+#define APC_ENTRY_SIZE(key_len) (ZEND_MM_ALIGNED_SIZE(XtOffsetOf(apc_cache_entry_t, key.val) + key_len + 1))
 
 #endif
 

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -55,7 +55,7 @@ static apc_iterator_item_t* apc_iterator_item_ctor(
 	array_init(&item->value);
 	ht = Z_ARRVAL(item->value);
 
-	item->key = zend_string_dup(entry->key, 0);
+	item->key = zend_string_dup(&entry->key, 0);
 
 	if (APC_ITER_TYPE & iterator->format) {
 		ZVAL_STR_COPY(&zv, apc_str_user);
@@ -178,18 +178,18 @@ static int apc_iterator_search_match(apc_iterator_t *iterator, apc_cache_entry_t
 #if PHP_VERSION_ID >= 70300
 		rval = pcre2_match(
 			php_pcre_pce_re(iterator->pce),
-			(PCRE2_SPTR) ZSTR_VAL(entry->key), ZSTR_LEN(entry->key),
+			(PCRE2_SPTR) ZSTR_VAL(&entry->key), ZSTR_LEN(&entry->key),
 			0, 0, iterator->re_match_data, php_pcre_mctx()) >= 0;
 #else
 		rval = pcre_exec(
 			iterator->pce->re, iterator->pce->extra,
-			ZSTR_VAL(entry->key), ZSTR_LEN(entry->key),
+			ZSTR_VAL(&entry->key), ZSTR_LEN(&entry->key),
 			0, 0, NULL, 0) >= 0;
 #endif
 	}
 
 	if (iterator->search_hash) {
-		rval = zend_hash_exists(iterator->search_hash, entry->key);
+		rval = zend_hash_exists(iterator->search_hash, &entry->key);
 	}
 
 	return rval;

--- a/php_apc.c
+++ b/php_apc.c
@@ -231,7 +231,7 @@ static PHP_MINIT_FUNCTION(apcu)
 			/* initialize shared memory allocator */
 			apc_sma_init(
 				&apc_sma, (void **) &apc_user_cache, (apc_sma_expunge_f) apc_cache_default_expunge,
-				APCG(shm_size), APC_ENTRY_MIN_ALLOC_SIZE, mmap_file_mask);
+				APCG(shm_size), APC_ENTRY_SIZE(0), mmap_file_mask);
 
 			REGISTER_LONG_CONSTANT(APC_SERIALIZER_CONSTANT, (zend_long)&_apc_register_serializer, CONST_PERSISTENT | CONST_CS);
 


### PR DESCRIPTION
The key is now implemented as the last part of apc_cache_entry_t, which is another step toward making entries relocatable in the future. Furthermore, this reduces the size of an entry by the size of a pointer and removes one memcpy() of apc_cache_entry_t during insertion.