### PR TITLE
Fix mem_size of cache entries

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -396,7 +396,6 @@ static void apc_cache_set_entry_values(apc_cache_entry_t *entry, const int32_t t
 	entry->ttl = ttl;
 	entry->next = NULL;
 	entry->ref_count = 0;
-	entry->mem_size = 0;
 	entry->nhits = 0;
 	entry->ctime = t;
 	entry->mtime = t;


### PR DESCRIPTION
This fixes a bug introduced in 453a849b / #554. The size was erroneously reset to 0 by apc_cache_set_entry_values() after it has been correctly set by apc_persist().