### PR TITLE
Make cache entries relocatable

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -58,7 +58,7 @@
 /* Defined in apc_persist.c */
 apc_cache_entry_t *apc_persist(
 		apc_sma_t *sma, apc_serializer_t *serializer, zend_string *key, const zval *val);
-zend_bool apc_unpersist(zval *dst, const zval *value, apc_serializer_t *serializer);
+zend_bool apc_unpersist(zval *dst, const apc_cache_entry_t *entry, apc_serializer_t *serializer);
 
 /* {{{ make_prime */
 static int const primes[] = {
@@ -985,7 +985,7 @@ PHP_APCU_API zend_bool apc_cache_delete(apc_cache_t *cache, zend_string *key)
 PHP_APCU_API zend_bool apc_cache_entry_fetch_zval(
 		apc_cache_t *cache, apc_cache_entry_t *entry, zval *dst)
 {
-	return apc_unpersist(dst, &entry->val, cache->serializer);
+	return apc_unpersist(dst, entry, cache->serializer);
 }
 /* }}} */
 


### PR DESCRIPTION
This makes the persistence representation of cache entries in shm position-independent by converting all pointers in an entry's zval value to offsets relative to the entry's starting address. During persistence, all (process local) pointers are converted and stored as offsets in shm. During unpersistence, the (process local) shm starting address of the entry is added to each offset before data access. This is necessary to make the whole cache relocatable or to develop defragmentation.