### PR TITLE
Compute the number of hash slots instead of using a fix default value

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -288,8 +288,8 @@ PHP_APCU_API apc_cache_t* apc_cache_create(apc_sma_t* sma, apc_serializer_t* ser
 	zend_long cache_size;
 	size_t nslots;
 
-	/* calculate number of slots */
-	nslots = make_prime(size_hint > 0 ? size_hint : 2000);
+	/* calculate number of slots. Default: 512 slots per MB of shared memory */
+	nslots = make_prime(size_hint > 0 ? (size_t)size_hint : sma->size / 2048);
 
 	/* allocate pointer by normal means */
 	cache = pemalloc(sizeof(apc_cache_t), 1);

--- a/php_apc.c
+++ b/php_apc.c
@@ -119,7 +119,7 @@ static PHP_INI_MH(OnUpdateShmSize) /* {{{ */
 PHP_INI_BEGIN()
 STD_PHP_INI_BOOLEAN("apc.enabled",      "1",    PHP_INI_SYSTEM, OnUpdateBool,              enabled,          zend_apcu_globals, apcu_globals)
 STD_PHP_INI_ENTRY("apc.shm_size",       "32M",  PHP_INI_SYSTEM, OnUpdateShmSize,           shm_size,         zend_apcu_globals, apcu_globals)
-STD_PHP_INI_ENTRY("apc.entries_hint",   "4096", PHP_INI_SYSTEM, OnUpdateLong,              entries_hint,     zend_apcu_globals, apcu_globals)
+STD_PHP_INI_ENTRY("apc.entries_hint",   "0",    PHP_INI_SYSTEM, OnUpdateLong,              entries_hint,     zend_apcu_globals, apcu_globals)
 STD_PHP_INI_ENTRY("apc.gc_ttl",         "3600", PHP_INI_SYSTEM, OnUpdateLong,              gc_ttl,           zend_apcu_globals, apcu_globals)
 STD_PHP_INI_ENTRY("apc.ttl",            "0",    PHP_INI_SYSTEM, OnUpdateLong,              ttl,              zend_apcu_globals, apcu_globals)
 STD_PHP_INI_ENTRY("apc.smart",          "0",    PHP_INI_SYSTEM, OnUpdateLong,              smart,            zend_apcu_globals, apcu_globals)

--- a/tests/iterator_006.phpt
+++ b/tests/iterator_006.phpt
@@ -5,7 +5,7 @@ APC: APCIterator formats
 --INI--
 apc.enabled=1
 apc.enable_cli=1
-apc.user_entries_hint=4096
+apc.entries_hint=4096
 --FILE--
 <?php
 $formats = array( 


### PR DESCRIPTION
The new default behavior is to use 512 slots per MB of shared memory, which keeps the hash table size < 0.4% of shm, which seems negligible. This should improve the default behavior, as it improves apcu's performance with many entries, and the hash table size now scales with the size of shared memory. Previously, a fixed value of 4096 at 32 MB shm was used as default, which corresponds to 128 slots per MB.

Closes #344