### PR TITLE
Add defragmentation to apcu

### DIFF
--- a/TECHNOTES.txt
+++ b/TECHNOTES.txt
@@ -258,8 +258,8 @@ form of a quick-start guide to start hacking on APCu.
     /* {{{ struct definition: apc_cache_entry_t */
     typedef struct apc_cache_entry_t apc_cache_entry_t;
     struct apc_cache_entry_t {
-        zval val;                /* the zval copied at store time */
-        uintptr_t next;          /* offset in shm of next entry in linked list */
+        uintptr_t next;          /* offset to next entry (MUST BE THE 1st FIELD OF THE STRUCT!) */
+        uintptr_t prev;          /* offset to previous entry / head-pointer of the linked list */
         zend_long ttl;           /* the ttl on this specific entry */
         zend_long ref_count;     /* the reference count of this entry */
         zend_long nhits;         /* number of hits to this entry */
@@ -268,6 +268,7 @@ form of a quick-start guide to start hacking on APCu.
         time_t dtime;            /* time entry was removed from cache */
         time_t atime;            /* time entry was last accessed */
         zend_long mem_size;      /* memory used */
+        zval val;                /* the zval copied at store time */
         zend_string key;         /* entry key (MUST BE THE LAST FIELD OF THE STRUCT!) */
     };
     /* }}} */

--- a/apc_cache.h
+++ b/apc_cache.h
@@ -49,8 +49,8 @@ struct apc_cache_slam_key_t {
 /* {{{ struct definition: apc_cache_entry_t */
 typedef struct apc_cache_entry_t apc_cache_entry_t;
 struct apc_cache_entry_t {
-	zval val;                /* the zval copied at store time */
-	uintptr_t next;          /* offset in shm of next entry in linked list */
+	uintptr_t next;          /* offset to next entry (MUST BE THE 1st FIELD OF THE STRUCT!) */
+	uintptr_t prev;          /* offset to previous entry / head-pointer of the linked list */
 	zend_long ttl;           /* the ttl on this specific entry */
 	zend_long ref_count;     /* the reference count of this entry */
 	zend_long nhits;         /* number of hits to this entry */
@@ -59,6 +59,7 @@ struct apc_cache_entry_t {
 	time_t dtime;            /* time entry was removed from cache */
 	time_t atime;            /* time entry was last accessed */
 	zend_long mem_size;      /* memory used */
+	zval val;                /* the zval copied at store time */
 	zend_string key;         /* entry key (MUST BE THE LAST FIELD OF THE STRUCT!) */
 };
 /* }}} */

--- a/apc_sma.h
+++ b/apc_sma.h
@@ -107,9 +107,27 @@ PHP_APCU_API void apc_sma_free_info(apc_sma_t* sma, apc_sma_info_t* info);
 PHP_APCU_API size_t apc_sma_get_avail_mem(apc_sma_t* sma);
 
 /*
-* apc_sma_api_get_avail_size will return true if at least size contiguous bytes are available to the sma
+* apc_sma_check_avail returns true if at least size bytes are available across all free blocks
 */
-PHP_APCU_API zend_bool apc_sma_get_avail_size(apc_sma_t* sma, size_t size);
+PHP_APCU_API zend_bool apc_sma_check_avail(apc_sma_t *sma, size_t size);
+
+/*
+* apc_sma_check_avail_contiguous returns true if at least size contiguous bytes can be allocated from the sma
+*/
+PHP_APCU_API zend_bool apc_sma_check_avail_contiguous(apc_sma_t *sma, size_t size);
+
+/*
+* apc_sma_defrag defragments the shared memory by shifting all allocated blocks to the left,
+* allowing all free blocks to be coalesced to one larger free block on the right side.
+*
+* The move() callback is called for each allocated block before it is moved. Therefore, move() can be used
+* to prepare for the move or to prevent the block from being moved by returning 0. The argument "data" is
+* passed as the first argument from apc_sma_defrag() to move(), while the old and the new address of the
+* allocation is passed as the 2nd and 3rd argument. The callback must not write to the new memory area
+* because the area is not yet allocated during the callback.
+*/
+typedef zend_bool (*apc_sma_move_f)(void *data, void *pointer_old, void *pointer_new);
+PHP_APCU_API void apc_sma_defrag(apc_sma_t *sma, void *data, apc_sma_move_f move);
 
 /* {{{ ALIGNWORD: pad up x, aligned to the system's word boundary */
 #define ALIGNWORD(x) ZEND_MM_ALIGNED_SIZE(x)

--- a/package.xml
+++ b/package.xml
@@ -75,6 +75,7 @@
     <file name="apc_025.phpt" role="test" />
     <file name="apc_099.phpt" role="test" />
     <file name="apc54_014.phpt" role="test" />
+    <file name="apc_defrag.phpt" role="test" />
     <file name="apc54_018.phpt" role="test" />
     <file name="apc_disabled.phpt" role="test" />
     <file name="apc_entry_001.phpt" role="test" />

--- a/tests/apc_defrag.phpt
+++ b/tests/apc_defrag.phpt
@@ -1,0 +1,85 @@
+--TEST--
+Test defragmentation
+--SKIPIF--
+<?php
+require_once(__DIR__ . '/skipif.inc');
+if (!function_exists('apcu_inc_request_time')) die('skip APC debug build required');
+?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.use_request_time=1
+apc.shm_size=1M
+--FILE--
+<?php
+
+// fill_cache() fills the cache with small entries with alternating ttl=1 and ttl=3
+function fill_cache(): int {
+    $i = 0;
+    $min_entry_size = apcu_sma_info(true)['avail_mem'];
+    apcu_store(sprintf("ttl1_%010d", $i), $i, 1);
+    $min_entry_size -= apcu_sma_info(true)['avail_mem'];
+
+    while (apcu_sma_info(true)['avail_mem'] >= $min_entry_size) {
+        $i++;
+        apcu_store(sprintf("ttl3_%010d", $i), $i, 3);
+
+        if (apcu_sma_info(true)['avail_mem'] >= $min_entry_size) {
+            apcu_store(sprintf("ttl1_%010d", $i), $i, 1);
+        }
+    }
+
+    return $i;
+}
+
+// store the first entry with ttl=1, which causes all entries
+// behind this entry to be moved during defragmentation
+apcu_store("ttl1_int", 123, 1);
+
+// store entries of different datatypes with ttl=3, which must be present after expiration + defragmentation
+apcu_store("ttl3_int", 123456789, 3);
+apcu_store("ttl3_string", "abc", 3);
+apcu_store("ttl3_array", [1, 2, "a", "b"], 3);
+apcu_store("ttl3_object", (object) ["prop1" => "val1", "prop2" => 2], 3);
+
+// safe available memory for later comparison
+$avail_before_filled = apcu_sma_info(true)['avail_mem'];
+
+// fill cache with alternating ttl=1 + ttl=3 entries
+fill_cache();
+
+// ensure that cache is full
+var_dump(apcu_sma_info(true)['avail_mem']);
+
+// expire all ttl1_* entries
+apcu_inc_request_time(2);
+
+// this insertion should trigger an default_expunge which removes all ttl1_ entries and performs a defragmentation
+var_dump(apcu_store("large_entry", str_repeat('x', 1000), 1));
+
+// delete large_entry to be able to check the available memory in the next step
+var_dump(apcu_delete("large_entry"));
+
+// the defragmentation should have freed more than 50% of the filled memory, because "ttl1_int" was also freed
+var_dump(apcu_sma_info(true)['avail_mem'] > $avail_before_filled / 2);
+
+// after the default expunge, all ttl1_ entries should not be present anymore
+var_dump(apcu_fetch("ttl1_int") === false);
+
+// all ttl3_ entries must be present (and correct after defragmentation)
+var_dump(apcu_fetch("ttl3_int") === 123456789);
+var_dump(apcu_fetch("ttl3_string") === "abc");
+var_dump(apcu_fetch("ttl3_array") === [1, 2, "a", "b"]);
+var_dump(apcu_fetch("ttl3_object") == (object) ["prop1" => "val1", "prop2" => 2]);
+
+?>
+--EXPECT--
+float(0)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
This adds defragmentation logic to apcu, which is performed during the default_expunge operation. It works by shifting all allocated blocks to the left (low addresses), allowing all free blocks to be coalesced to one larger free block on the right side.