### PR TITLE
Update atime and statistics when accessing entries with apcu_exists()

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -880,7 +880,7 @@ PHP_APCU_API zend_bool apc_cache_exists(apc_cache_t* cache, zend_string *key, ti
 		return 0;
 	}
 
-	entry = apc_cache_rlocked_find_nostat(cache, key, t);
+	entry = apc_cache_rlocked_find(cache, key, t);
 	apc_cache_runlock(cache);
 
 	return entry != NULL;

--- a/tests/apc_020.phpt
+++ b/tests/apc_020.phpt
@@ -14,10 +14,9 @@ apc.shm_size=1M
 --FILE--
 <?php
 
-apcu_store("no_ttl_unaccessed", 12);
+apcu_store("no_ttl_unaccessed", str_repeat('x', 500));
 apcu_store("no_ttl_accessed", 24);
 apcu_store("ttl", 42, 3);
-apcu_store("dummy", str_repeat('x', 1000));
 
 apcu_inc_request_time(1);
 apcu_fetch("no_ttl_accessed");
@@ -26,10 +25,11 @@ apcu_inc_request_time(1);
 
 // Fill the cache
 $i = 0;
-while (apcu_exists("dummy")) {
+do {
+    $tmp_avail = apcu_sma_info(true)['avail_mem'];
     apcu_store("key" . $i, str_repeat('x', 500));
     $i++;
-}
+} while (apcu_sma_info(true)['avail_mem'] < $tmp_avail);
 
 var_dump(apcu_fetch("no_ttl_unaccessed"));
 var_dump(apcu_fetch("no_ttl_accessed"));


### PR DESCRIPTION
The access time and access statistics are now updated when using apcu_exists(). The documentation does not indicate that this function behaves differently than apcu_fetch() in this regard. This should also help to use values other than 0 for apc.ttl, since entries frequently checked with apcu_exists() no longer soft-expire.