### PR TITLE
Fix Linux CI for PHP 7.x to not silently abort tests

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -19,6 +19,8 @@ jobs:
         run: phpize
       - name: configure
         run: ./configure --enable-apcu-debug
+      - name: Fix missing PHP_EXECUTABLE in Makefile for PHP 7.x
+        run: sed -i -e 's/^PHP_EXECUTABLE = NONE$/PHP_EXECUTABLE = \/usr\/bin\/php/' Makefile
       - name: make
         run: make
       - name: test


### PR DESCRIPTION
All PHP 7.x Linux pipelines silently aborted the tests because the PHP executable could not be found. This was caused by the definition of "PHP_EXECUTABLE = NONE" in the Makefile, as "php-config --php-binary" returned "NONE" during ./configure. Since it seems time-consuming to fix the root cause, this is a temporary workaround until PHP 7.x is removed from the CI pipeline.

Closes #566