### PR TITLE
Add cache cleanup and defragmentation counts to apcu_cache_info()

### DIFF
--- a/apc.php
+++ b/apc.php
@@ -804,6 +804,8 @@ EOB;
             <tr class=tr-0><td class=td-0>Hit Rate</td><td>$hit_rate_user cache requests/second</td></tr>
             <tr class=tr-1><td class=td-0>Miss Rate</td><td>$miss_rate_user cache requests/second</td></tr>
             <tr class=tr-0><td class=td-0>Insert Rate</td><td>$insert_rate_user cache requests/second</td></tr>
+            <tr class=tr-1><td class=td-0>Cache cleanup count</td><td>{$cache['cleanups']}</td></tr>
+            <tr class=tr-0><td class=td-0>Cache defragmentation count</td><td>{$cache['defragmentations']}</td></tr>
             <tr class=tr-1><td class=td-0>Cache full count</td><td>{$cache['expunges']}</td></tr>
         </tbody>
         </table>

--- a/apc_cache.h
+++ b/apc_cache.h
@@ -71,7 +71,9 @@ typedef struct _apc_cache_header_t {
 	zend_long nhits;                /* hit count */
 	zend_long nmisses;              /* miss count */
 	zend_long ninserts;             /* insert count */
-	zend_long nexpunges;            /* expunge count */
+	zend_long ncleanups;            /* default expunge count */
+	zend_long ndefragmentations;    /* defragmentation count */
+	zend_long nexpunges;            /* real expunge count */
 	zend_long nentries;             /* entry count */
 	zend_long mem_size;             /* used */
 	time_t stime;                   /* start time */

--- a/package.xml
+++ b/package.xml
@@ -60,6 +60,10 @@
        removing expired entries was too small. This could be useful if performance degrades due to
        executing the logic to remove expired entries (+ defragmentation) too frequently during
        periods of high memory usage.
+     - The number of cache cleanups performed (removal of expired entries) is now available
+       in the array returned by apcu_cache_info() (via array key "cleanups").
+     - The number of defragmentations performed is now available in the array returned by
+       apcu_cache_info() (via array key "defragmentations").
      - Fixed several issues that caused inserting new entries to fail unexpectedly.
 
      Internal changes:


### PR DESCRIPTION
The cache cleanup and defragmentation counts are now available in the array returned by apcu_cache_info().