### PR TITLE
Add test that a repeated unpersist doesn't break representation

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -115,6 +115,7 @@
     <file name="apc_entry_recursion.phpt" role="test" />
     <file name="apcu_fetch_empty_array_reference.phpt" role="test" />
     <file name="apc_inc_perf.phpt" role="test" />
+    <file name="apc_repeated_unpersist.phpt" role="test" />
     <file name="apc_store_array_int_keys.phpt" role="test" />
     <file name="apc_store_array_with_refs.phpt" role="test" />
     <file name="apc_store_reference.phpt" role="test" />

--- a/tests/apc_repeated_unpersist.phpt
+++ b/tests/apc_repeated_unpersist.phpt
@@ -1,0 +1,73 @@
+--TEST--
+APCU: Test that repeated unpersist does not break the persistence representation in SHM
+--SKIPIF--
+<?php
+require_once(__DIR__ . '/skipif.inc');
+?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.serializer=default
+apc.shm_size=1M
+--FILE--
+<?php
+
+// This test must be performed with apc.serializer=default (instead of apc.serializer=php).
+// Otherwise all arrays will be persisted using the serializer, which means that not all code paths will be tested.
+
+// store entries of different types
+$tmp = [1, "a", []];
+apcu_store("int", 123);
+apcu_store("string", "abc");
+apcu_store("object", (object) ["prop1" => "val1", "prop2" => 2]);
+apcu_store("array_empty", []);
+apcu_store("array_simple", $tmp);
+apcu_store("array_nested", [$tmp]);
+apcu_store("array_referenced", [&$tmp, &$tmp]);
+
+echo "1st unpersist:\n";
+var_dump(apcu_fetch("int") === 123);
+var_dump(apcu_fetch("string") === "abc");
+var_dump(apcu_fetch("object") == (object) ["prop1" => "val1", "prop2" => 2]);
+var_dump(apcu_fetch("array_empty") === []);
+var_dump(apcu_fetch("array_simple") === $tmp);
+var_dump(apcu_fetch("array_nested") === [$tmp]);
+var_dump(apcu_fetch("array_referenced") === [&$tmp, &$tmp]);
+
+echo "2nd unpersist (check, if the 1st unpersist didn't break the representation in SHM):\n";
+var_dump(apcu_fetch("int") === 123);
+var_dump(apcu_fetch("string") === "abc");
+var_dump(apcu_fetch("object") == (object) ["prop1" => "val1", "prop2" => 2]);
+var_dump(apcu_fetch("array_empty") === []);
+var_dump(apcu_fetch("array_simple") === $tmp);
+var_dump(apcu_fetch("array_nested") === [$tmp]);
+var_dump(apcu_fetch("array_referenced") === [&$tmp, &$tmp]);
+
+echo "Check if the reference has been preserved:\n";
+$tmp = apcu_fetch("array_referenced");
+$tmp[0][0] = 2;
+$tmp[0][1] = "b";
+var_dump($tmp[1][0] === 2);
+var_dump($tmp[1][1] === "b");
+
+?>
+--EXPECT--
+1st unpersist:
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+2nd unpersist (check, if the 1st unpersist didn't break the representation in SHM):
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Check if the reference has been preserved:
+bool(true)
+bool(true)


### PR DESCRIPTION
The purpose of this test is to ensure that the unpersist-code does not accidentally change the persistence representation in SHM (e.g., by the offset -> pointer conversion), causing a second unpersist to fail.