### PR TITLE
Adapt test for 8.5, this is now a recoverable error

### DIFF
--- a/tests/apc_entry_003.phpt
+++ b/tests/apc_entry_003.phpt
@@ -9,7 +9,11 @@ apc.enable_cli=1
 <?php
 $value = apcu_entry("test", function($key) {
     // Fatal error
-    class X { use T; }
+    try {
+        class X { use T; }
+    } catch (Error $e) {
+        echo 'Fatal error: ' . $e->getMessage() . "\n";
+    }
 });
 ?>
 --EXPECTF--


### PR DESCRIPTION
As fatal_error_backtraces is On by default

```
TEST 37/76 [tests/apc_entry_003.phpt]
========DIFF========
     Fatal error: %s
002+ Stack trace:
003+ #0 [internal function]: {closure:/dev/shm/BUILD/php85-php-pecl-apcu-5.1.25-build/php85-php-pecl-apcu-5.1.25/apcu-5.1.25/tests/apc_entry_003.php:2}('test')
004+ #1 /dev/shm/BUILD/php85-php-pecl-apcu-5.1.25-build/php85-php-pecl-apcu-5.1.25/apcu-5.1.25/tests/apc_entry_003.php(2): apcu_entry('test', Object(Closure))
005+ #2 {main}
006+   thrown in /dev/shm/BUILD/php85-php-pecl-apcu-5.1.25-build/php85-php-pecl-apcu-5.1.25/apcu-5.1.25/tests/apc_entry_003.php on line 4
========DONE========
FAIL APC: apcu_entry (fatal error) [tests/apc_entry_003.phpt] 
```