### PR TITLE
Fix stacking of default expunge operations

### DIFF
--- a/apc_cache.h
+++ b/apc_cache.h
@@ -254,7 +254,7 @@ PHP_APCU_API void apc_cache_serializer(apc_cache_t* cache, const char* name);
 *
 * The TTL of an entry takes precedence over the TTL of a cache
 */
-PHP_APCU_API void apc_cache_default_expunge(apc_cache_t* cache, size_t size);
+PHP_APCU_API zend_bool apc_cache_default_expunge(apc_cache_t* cache, size_t size);
 
 /*
 * apc_cache_entry: generate and create or fetch an entry

--- a/apc_sma.c
+++ b/apc_sma.c
@@ -326,8 +326,8 @@ restart:
 
 	/* Expunge cache in hope of freeing up memory, but only once */
 	if (!nuked) {
-		sma->expunge(*sma->data, n);
-		nuked = 1;
+		/* nuke is not set if expunge() was skipped internally to get another try */
+		nuked = sma->expunge(*sma->data, n);
 		goto restart;
 	}
 

--- a/apc_sma.h
+++ b/apc_sma.h
@@ -52,7 +52,7 @@ struct apc_sma_info_t {
 };
 /* }}} */
 
-typedef void (*apc_sma_expunge_f)(void *pointer, size_t size); /* }}} */
+typedef zend_bool (*apc_sma_expunge_f)(void *pointer, size_t size); /* }}} */
 
 /* {{{ struct definition: apc_sma_t */
 typedef struct _apc_sma_t {


### PR DESCRIPTION
Under high load, multiple parallel insert operations could trigger multiple default expunge operations at the same time. To prevent this, pending default expunge operations are now aborted if another default expunge operation has run in the meantime.