### PR TITLE
Remove all entries that cannot expire during default expunge

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -817,7 +817,8 @@ PHP_APCU_API zend_bool apc_cache_default_expunge(apc_cache_t* cache, size_t size
 		while (*entry_offset) {
 			apc_cache_entry_t *entry = ENTRYAT(*entry_offset);
 
-			if (apc_cache_entry_expired(cache, entry, t)) {
+			/* remove all entries that are expired or cannot expire via hard or soft ttl */
+			if (apc_cache_entry_expired(cache, entry, t) || (!cache->ttl && !entry->ttl)) {
 				apc_cache_wlocked_remove_entry(cache, entry);
 				continue;
 			}


### PR DESCRIPTION
When the cache is full, all entries that cannot expire are now removed by the first cleanup pass. This improves the performance of the default- expunge operation when apc.ttl = 0 and the application largely does not use an explicit TTL. Furthermore, this is closer to the behavior of APCu versions <= 5.1.24. However, unlike APCu <= 5.1.24, the first cleanup pass still retains all entries that expire via hard- or soft-ttl and have not yet expired, if apc.ttl = 0.