### PR TITLE
Fix releasing of ref_count in apc_cache_store()

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -573,14 +573,16 @@ PHP_APCU_API zend_bool apc_cache_store(
 	php_apc_try {
 		ret = apc_cache_wlocked_insert(cache, entry, exclusive);
 	} php_apc_finally {
-		/* release entry, because the ref_count of a new entry is initialized to 1 during allocation */
-		apc_cache_entry_release(cache, entry);
 		apc_cache_wunlock(cache);
-	} php_apc_end_try();
 
-	if (!ret) {
-		free_entry(cache, entry);
-	}
+		if (ret) {
+			/* release entry, because the ref_count of a new entry is initialized to 1 during allocation */
+			apc_cache_entry_release(cache, entry);
+		} else {
+			/* the entry mustn't be released before it is freed to prevent defragmentation from moving the entry */
+			free_entry(cache, entry);
+		}
+	} php_apc_end_try();
 
 	return ret;
 } /* }}} */


### PR DESCRIPTION
In apc_cache_store(), the ref_count was decremented even when the entry needed to be deleted. This allowed the entry to be moved by defragmentation (by another process) before deletion. As a result, the pointer no longer pointed to the desired entry during deletion, causing segmentation faults.