### PR TITLE
Prevent unnecessarily frequent default expunge operations

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -308,7 +308,7 @@ PHP_APCU_API int APC_UNSERIALIZER_NAME(php) (APC_UNSERIALIZER_ARGS)
 	return 1;
 }
 
-PHP_APCU_API apc_cache_t* apc_cache_create(apc_sma_t* sma, apc_serializer_t* serializer, zend_long size_hint, zend_long gc_ttl, zend_long ttl, zend_long smart, zend_bool defend) {
+PHP_APCU_API apc_cache_t* apc_cache_create(apc_sma_t* sma, apc_serializer_t* serializer, zend_long size_hint, zend_long gc_ttl, zend_long ttl, double expunge_threshold, zend_bool defend) {
 	apc_cache_t* cache;
 	zend_long cache_size;
 	size_t nslots;
@@ -350,7 +350,7 @@ PHP_APCU_API apc_cache_t* apc_cache_create(apc_sma_t* sma, apc_serializer_t* ser
 	cache->nslots = nslots;
 	cache->gc_ttl = gc_ttl;
 	cache->ttl = ttl;
-	cache->smart = smart;
+	cache->expunge_threshold = expunge_threshold;
 	cache->defend = defend;
 
 	/* header lock */
@@ -794,11 +794,20 @@ PHP_APCU_API zend_bool apc_cache_default_expunge(apc_cache_t* cache, size_t size
 		return 0;
 	}
 
-	/* smart > 1 increases the probability of a full cache wipe,
-	 * so expunge() is called less often when memory is low. */
-	size = (cache->smart > 0L) ? (size_t) (cache->smart * size) : size;
+	/* expunge_threshold specifies the percentage of memory that must be free after removing
+	 * expired entries. If not enough memory could be freed, a full cache wipe will be performed,
+	 * so that the default expunge operation is called less often when memory pressure is high. */
+	size += cache->sma->size / 100 * cache->expunge_threshold;
 
-	/* look for junk */
+	/* if size >= total shm size (e.g., if expunge_threshold >= 100), skip removing
+	 * expired entries and defragmentation as this always results in a real expunge */
+	if (size >= cache->sma->size) {
+		apc_cache_wlocked_real_expunge(cache);
+		apc_cache_wlocked_gc(cache);
+		goto end_lbl;
+	}
+
+	/* remove expired entries */
 	for (i = 0; i < cache->nslots; i++) {
 		uintptr_t *entry_offset = &cache->slots[i];
 		while (*entry_offset) {

--- a/apc_globals.h
+++ b/apc_globals.h
@@ -41,7 +41,7 @@ ZEND_BEGIN_MODULE_GLOBALS(apcu)
 	zend_long entries_hint;      /* hint at the number of entries expected */
 	zend_long gc_ttl;            /* parameter to apc_cache_create */
 	zend_long ttl;               /* parameter to apc_cache_create */
-	zend_long smart;             /* smart value */
+	double expunge_threshold;    /* expunge if less than this percentage of shm is free after cleanup */
 
 #ifdef APC_MMAP
 	char *mmap_file_mask;         /* mktemp-style file-mask to pass to mmap */

--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,19 @@
  <notes>
   - Entries in the garbage collection list are now cleaned up during apcu_clear_cache().
     Previously these entries remained untouched in the shared memory.
+  - Shared memory for new entries is allocated faster in scenarios with many free memory blocks.
+    This should improve APCu's insertion performance when entries are frequently deleted or
+    replaced, or when APCu is used with larger amounts of memory.
+  - The apc.expunge_threshold specifies the percentage of shared memory that must be free
+    after expired entries have been removed during the default expunge operation. If not enough
+    memory has been freed, the entire cache is discarded (expunge). This prevents the default
+    expunge operation from being called too often, thus preventing unnecessary cpu load.
+    The default value of apc.expunge_threshold is 0.5. This means that the entire cache will be
+    discarded if less than 0.5% of shared memory is free after removing all expired entries.
+    When apc.expunge_threshold is set to 100, the default expunge operation no longer attempts
+    to free memory by removing expired entries. Instead, it always discards the entire cache.
+  - The apc.smart configuration setting has been removed because it has been superseded by
+    apc.expunge_threshold, which should provide more predictable results.
 
   Internal changes:
   - Added stress test to CI. This test will hopefully help to detect unexpected behavior


### PR DESCRIPTION
A full cache wipe is now performed if too little SHM has been freed by removing expired entries during the default expunge operation. This is intended to prevent unnecessarily frequent calls of the default expunge operation, which should reduce cpu load in some cases. The new configuration setting apc.expunge_threshold defaults to 0.5 (0.5%) and specifies the percentage of SHM that must be available after expired entries have been removed during the default expunge operation. Since apc.expunge_threshold replaces apc.smart, apc.smart has been removed.