### PR TITLE
Remove report_memleaks ini directive from tests

### DIFF
--- a/tests/apc_006.phpt
+++ b/tests/apc_006.phpt
@@ -9,7 +9,6 @@ if (PHP_VERSION_ID >= 70300) die('skip Only for PHP < 7.3');
 apc.enabled=1
 apc.enable_cli=1
 apc.serializer=php
-report_memleaks=0
 --FILE--
 <?php
 

--- a/tests/apc_006_php73.phpt
+++ b/tests/apc_006_php73.phpt
@@ -10,7 +10,6 @@ if (PHP_VERSION_ID >= 80100) die('skip Only for PHP < 8.1');
 apc.enabled=1
 apc.enable_cli=1
 apc.serializer=php
-report_memleaks=0
 --FILE--
 <?php
 

--- a/tests/apc_006_php81.phpt
+++ b/tests/apc_006_php81.phpt
@@ -9,7 +9,6 @@ if (PHP_VERSION_ID < 80100) die('skip Only for PHP >= 8.1');
 apc.enabled=1
 apc.enable_cli=1
 apc.serializer=php
-report_memleaks=0
 --FILE--
 <?php
 


### PR DESCRIPTION
The "report_memleaks" ini directive is deprecated in PHP 8.5 and has therefore been removed from the tests.