### PR TITLE
Perform garbage collection during apc_cache_clear()

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -756,8 +756,10 @@ PHP_APCU_API void apc_cache_clear(apc_cache_t* cache)
 	/* expunge cache */
 	apc_cache_wlocked_real_expunge(cache);
 
+	/* garbage collection */
+	apc_cache_wlocked_gc(cache);
+
 	/* set info */
-	cache->header->stime = apc_time();
 	cache->header->ncleanups = 0;
 	cache->header->ndefragmentations = 0;
 	cache->header->nexpunges = 0;

--- a/package.xml
+++ b/package.xml
@@ -39,6 +39,9 @@
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
+  - Entries in the garbage collection list are now cleaned up during apcu_clear_cache().
+    Previously these entries remained untouched in the shared memory.
+
   Internal changes:
   - Added stress test to CI. This test will hopefully help to detect unexpected behavior
     that can only occur when multiple processes access the cache simultaneously.


### PR DESCRIPTION
When the whole cache is wiped via apc_cache_clear(), the entries in the garbage collection list are now cleaned up, too. Previously these entries remained untouched in the shared memory.