### PR TITLE
Use proper format specifiers

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -301,7 +301,7 @@ PHP_APCU_API int APC_UNSERIALIZER_NAME(php) (APC_UNSERIALIZER_ARGS)
 	BG(serialize_lock)--;
 
 	if (!result) {
-		php_error_docref(NULL, E_NOTICE, "Error at offset %td of %zd bytes", tmp - buf, buf_len);
+		php_error_docref(NULL, E_NOTICE, "Error at offset %td of %zu bytes", tmp - buf, buf_len);
 		ZVAL_NULL(value);
 		return 0;
 	}

--- a/apc_mmap.c
+++ b/apc_mmap.c
@@ -71,7 +71,7 @@ static int apc_mmap_hugepage_flags(size_t size, zend_long hugepage_size)
 
 	if (!log2_page_size || (log2_page_size & MAP_HUGE_MASK) != log2_page_size) {
 		// maybe hugepage size is too large or small
-		zend_error_noreturn(E_CORE_ERROR, "Invalid hugepage size: %ld", hugepage_size);
+		zend_error_noreturn(E_CORE_ERROR, "Invalid hugepage size: " ZEND_LONG_FMT, hugepage_size);
 	}
 
 	return MAP_HUGETLB | ((unsigned int)log2_page_size << MAP_HUGE_SHIFT);
@@ -118,7 +118,7 @@ void *apc_mmap(char *file_mask, size_t size, zend_long hugepage_size)
 
 	if ((long)shmaddr == -1) {
 		if (hugepage_size) {
-			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: Failed to mmap %zu bytes with hugepage size %ld. apc.shm_size may be too large, apc.mmap_hugepage_size may be invalid, or the system lacks sufficient reserved hugepages.", size, hugepage_size);
+			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: Failed to mmap %zu bytes with hugepage size " ZEND_LONG_FMT ". apc.shm_size may be too large, apc.mmap_hugepage_size may be invalid, or the system lacks sufficient reserved hugepages.", size, hugepage_size);
 		} else {
 			zend_error_noreturn(E_CORE_ERROR, "apc_mmap: Failed to mmap %zu bytes. apc.shm_size may be too large.", size);
 		}

--- a/apc_shm.c
+++ b/apc_shm.c
@@ -53,7 +53,7 @@ static int apc_shm_create(size_t size)
 
 	oflag = IPC_CREAT | SHM_R | SHM_A;
 	if ((shmid = shmget(key, size, oflag)) < 0) {
-		zend_error_noreturn(E_CORE_ERROR, "apc_shm_create: shmget(%ld, %zd, %d) failed: %s. It is possible that the chosen SHM segment size is higher than the operation system allows. Linux has usually a default limit of 32MB per segment.", (long) key, size, oflag, strerror(errno));
+		zend_error_noreturn(E_CORE_ERROR, "apc_shm_create: shmget(%ld, %zu, %d) failed: %s. It is possible that the chosen SHM segment size is higher than the operation system allows. Linux has usually a default limit of 32MB per segment.", (long) key, size, oflag, strerror(errno));
 	}
 
 	return shmid;


### PR DESCRIPTION
ZEND_LONG_FMT should be used for the type zend_long to avoid problems on platforms where long and zend_long have a different size. In addition, %zu is now consistently used to format size_t.