### PR TITLE
Replace XtOffsetOf() with offsetof() for PHP 8.6

### DIFF
--- a/apc_cache.h
+++ b/apc_cache.h
@@ -295,7 +295,7 @@ static inline void apc_cache_runlock(apc_cache_t *cache) {
 }
 
 /* APC_ENTRY_SIZE takes into account the trailing key-string + terminating 0-byte */
-#define APC_ENTRY_SIZE(key_len) (ZEND_MM_ALIGNED_SIZE(XtOffsetOf(apc_cache_entry_t, key.val) + key_len + 1))
+#define APC_ENTRY_SIZE(key_len) (ZEND_MM_ALIGNED_SIZE(offsetof(apc_cache_entry_t, key.val) + key_len + 1))
 
 /* ENTRYAT and ENTRYOF are used to convert between offsets and pointers to cache entries.
  * Both expect the presence of cache->header that points to the cache header in the

--- a/apc_iterator.c
+++ b/apc_iterator.c
@@ -548,7 +548,7 @@ int apc_iterator_init(int module_number) {
 
 	apc_iterator_object_handlers.clone_obj = NULL;
 	apc_iterator_object_handlers.free_obj = apc_iterator_free;
-	apc_iterator_object_handlers.offset = XtOffsetOf(apc_iterator_t, obj);
+	apc_iterator_object_handlers.offset = offsetof(apc_iterator_t, obj);
 
 	return SUCCESS;
 }

--- a/apc_iterator.h
+++ b/apc_iterator.h
@@ -69,7 +69,7 @@ typedef struct _apc_iterator_t {
 	zend_object obj;
 } apc_iterator_t;
 
-#define apc_iterator_fetch_from(o) ((apc_iterator_t*)((char*)o - XtOffsetOf(apc_iterator_t, obj)))
+#define apc_iterator_fetch_from(o) ((apc_iterator_t*)((char*)o - offsetof(apc_iterator_t, obj)))
 #define apc_iterator_fetch(z) apc_iterator_fetch_from(Z_OBJ_P(z))
 
 typedef struct _apc_iterator_item_t {


### PR DESCRIPTION
PHP 8.6 removed `XtOffsetOf()`, which was an alias for the standard C `offsetof()` macro. Replaced all usages in `apc_cache.h` and `apc_iterator`  with` offsetof()` directly.

Ref https://github.com/php/php-src/commit/7114314c5a96c362b95663f7e7c9184586721f58

>  The XtOffsetOf() alias of C’s offsetof() macro has been removed. Use  offsetof() directly.