### PR TITLE
Add new release workflow to publish files required by PIE

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,5 +1,10 @@
 name: Build and Test
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    # Trigger on all branches, but not on tags, to prevent CI runs if a release is published (which pushes a tag)
+    branches: ['**']
+
 jobs:
   common:
     runs-on: ubuntu-latest
@@ -8,6 +13,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Check files referenced in package.xml
         run: ./checkrel.sh
+
+  # Build and test on Linux
   ubuntu:
     strategy:
       matrix:
@@ -35,19 +42,20 @@ jobs:
             make test TESTS="--show-diff -d apc.serializer=php tests"
             make test TESTS="--show-diff -d apc.serializer=default -d opcache.enable_cli=1 tests"
             make test TESTS="--show-diff -d apc.serializer=php -d opcache.enable_cli=1 tests"
+
+  # Build and test on Windows
   windows:
     strategy:
       matrix:
-        php-version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
-        arch: [x64]
+        php-version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+        arch: [x64, x86]
         ts: [nts, ts]
     runs-on: windows-2022
     steps:
       - name: Checkout apcu
         uses: actions/checkout@v6
-      # Packaging and artifact upload are handled automatically by the builder.
-      # See https://github.com/php/php-windows-builder
-      - name: Build the extension
+      # The builder handles building, testing and artifact packaging/upload automatically
+      - name: Build and test the extension
         uses: php/php-windows-builder/extension@v1
         with:
           php-version: ${{ matrix.php-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+# This workflow is triggered if a new release or prerelease is published on GitHub (no drafts).
+# It builds and publishes zip-files with prebuilt Windows DLLs as release artifacts. These
+# artifacts are required by PIE (PHP Installer for Extensions). See https://github.com/php/pie
+# and https://github.com/php/php-windows-builder for more information.
+name: Release
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+  release:
+    types: [published]
+
+jobs:
+  # Build and test on Windows
+  windows:
+    strategy:
+      matrix:
+        php-version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+        arch: [x64, x86]
+        ts: [nts, ts]
+    runs-on: windows-2022
+    steps:
+      - name: Checkout apcu
+        uses: actions/checkout@v6
+      # The builder handles building, testing and artifact packaging/upload automatically
+      - name: Build and test the extension
+        uses: php/php-windows-builder/extension@v1
+        with:
+          php-version: ${{ matrix.php-version }}
+          arch: ${{ matrix.arch }}
+          ts: ${{ matrix.ts }}
+          args: --enable-apcu --enable-debug-pack
+          run-tests: true
+          test-runner-args: "--show-diff tests"
+
+  # Upload zip-files with prebuilt Windows DLLs to the release (required for PIE)
+  release_windows_pie:
+    if: ${{ github.event_name == 'release' }}
+    needs: windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload artifacts to the release
+        uses: php/php-windows-builder/release@v1
+        with:
+          release: ${{ github.event.release.tag_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.xml
+++ b/package.xml
@@ -54,6 +54,9 @@
   - Fix version comparison in apc.php.
   - Fix php_apc_finally to prevent a bailout within a php_apc_finally block from re-triggering
     the finally block again, which can cause the PHP process to crash.
+  - Add a new GitHub workflow that automatically uploads ZIP files containing pre-built Windows
+    DLLs as assets to new releases. As a result, the installation of APCu via PIE should work
+    more reliably for Windows users starting with the next release.
 
   Internal changes:
   - Added stress test to CI. This test will hopefully help to detect unexpected behavior


### PR DESCRIPTION
This commit introduces a new release workflow which is triggered if a new release or prerelease is published on GitHub. It builds zip-files with prebuilt Windows Dlls and uploads them as artifacts to the release. These artifacts are required by PIE (PHP Installer for Extensions) to function correctly for Windows users. The CI pipeline has been modified to build and test the extension for all Windows PHP versions for which installation packages are available via PECL or PIE.

Closes #568