### PR TITLE
Avoid unnecessary hash value computation for serialized data

### DIFF
--- a/apc_persist.c
+++ b/apc_persist.c
@@ -294,19 +294,18 @@ static zend_string *apc_persist_copy_cstr(
 	ZSTR_LEN(str) = buf_len;
 	memcpy(ZSTR_VAL(str), orig_buf, buf_len);
 	ZSTR_VAL(str)[buf_len] = '\0';
-	zend_string_hash_val(str);
 
 	return str;
 }
 
 static zend_string *apc_persist_copy_zstr_no_add(
-		apc_persist_context_t *ctxt, const zend_string *orig_str) {
+		apc_persist_context_t *ctxt, zend_string *orig_str) {
 	return apc_persist_copy_cstr(
-		ctxt, ZSTR_VAL(orig_str), ZSTR_LEN(orig_str), ZSTR_H(orig_str));
+		ctxt, ZSTR_VAL(orig_str), ZSTR_LEN(orig_str), ZSTR_HASH(orig_str));
 }
 
 static inline zend_string *apc_persist_copy_zstr(
-		apc_persist_context_t *ctxt, const zend_string *orig_str) {
+		apc_persist_context_t *ctxt, zend_string *orig_str) {
 	zend_string *str = apc_persist_copy_zstr_no_add(ctxt, orig_str);
 	apc_persist_add_already_allocated(ctxt, orig_str, str);
 	return str;

--- a/package.xml
+++ b/package.xml
@@ -56,7 +56,11 @@
     the finally block again, which can cause the PHP process to crash.
   - Add a new GitHub workflow that automatically uploads ZIP files containing pre-built Windows
     DLLs as assets to new releases. As a result, the installation of APCu via PIE should work
-    more reliably for Windows users starting with the next release.
+    more reliably for Windows users starting with this release.
+  - For entries storing the data in a serialized form, the hash value of the serialized data string
+    is no longer computed, as the hash is not needed for the unserialization. This significantly
+    improves performance when saving larger objects or arrays by using a serializer (tested with
+    the PHP serializer, which is currently the default).
 
   Internal changes:
   - Added stress test to CI. This test will hopefully help to detect unexpected behavior


### PR DESCRIPTION
For entries storing the data in a serialized form, the hash value of the serialized data string is no longer computed, as the hash is not needed for the unserialization. Synthetic benchmarks show a significant performance gain when saving larger objects or arrays by using the PHP serializer (which is the default).