### PR TITLE
Use Homebrew include directory for pcre2.h on macOS if necessary

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -43,6 +43,33 @@ jobs:
             make test TESTS="--show-diff -d apc.serializer=default -d opcache.enable_cli=1 tests"
             make test TESTS="--show-diff -d apc.serializer=php -d opcache.enable_cli=1 tests"
 
+  # Build and test on macOS (Arm64)
+  macos:
+    strategy:
+      matrix:
+        version: ["latest"]
+        os: [macos-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout apcu
+        uses: actions/checkout@v6
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{matrix.version}}
+      - name: phpize
+        run: phpize
+      - name: configure
+        run: ./configure --enable-apcu-debug
+      - name: make
+        run: make
+      - name: test
+        run: |
+          make test TESTS="--show-diff -d apc.serializer=default tests"
+          make test TESTS="--show-diff -d apc.serializer=php tests"
+          make test TESTS="--show-diff -d apc.serializer=default -d opcache.enable_cli=1 tests"
+          make test TESTS="--show-diff -d apc.serializer=php -d opcache.enable_cli=1 tests"
+
   # Build and test on Windows
   windows:
     strategy:

--- a/config.m4
+++ b/config.m4
@@ -201,6 +201,25 @@ if test "$PHP_APCU" != "no"; then
 
   AC_CHECK_FUNCS(sigaction)
 
+  dnl Ensure that the compiler can include pcre2.h if it was installed via Homebrew on macOS
+  dnl See https://github.com/krakjoe/apcu/issues/572
+  if test "$PHP_EXTERNAL_PCRE" != "no"; then
+    AC_CHECK_HEADER([pcre2.h], [apcu_pcre2_found=yes], [apcu_pcre2_found=no], [#define PCRE2_CODE_UNIT_WIDTH 8])
+    if test "$apcu_pcre2_found" = "no"; then
+      AC_CHECK_PROG([apcu_brew], [brew], [brew])
+      if test -n "$apcu_brew"; then
+        apcu_homebrew_include_dir="$($apcu_brew --prefix 2> /dev/null)/include"
+        AC_MSG_CHECKING([for pcre2.h in homebrew include directory $apcu_homebrew_include_dir])
+        if test -f "$apcu_homebrew_include_dir/pcre2.h"; then
+          PHP_ADD_INCLUDE([$apcu_homebrew_include_dir])
+          AC_MSG_RESULT([yes])
+        else
+          AC_MSG_RESULT([no])
+        fi
+      fi
+    fi
+  fi
+
   for i in -Wall -Wextra -Wno-clobbered -Wno-unused-parameter; do
     AX_CHECK_COMPILE_FLAG([$i], [APCU_CFLAGS="$APCU_CFLAGS $i"])
   done

--- a/package.xml
+++ b/package.xml
@@ -61,6 +61,8 @@
     is no longer computed, as the hash is not needed for the unserialization. This significantly
     improves performance when saving larger objects or arrays by using a serializer (tested with
     the PHP serializer, which is currently the default).
+  - Fix build on macOS. If pcre2 was installed via Homebrew, the header file pcre2.h wasn't found
+    during the build process.
 
   Internal changes:
   - Added stress test to CI. This test will hopefully help to detect unexpected behavior
@@ -70,6 +72,7 @@
   - The pipeline now uses php/php-windows-builder for building and testing on Windows.
   - Fix potential compiler warnings by using proper format specifiers.
   - Transition to actions/checkout@v6 because of the Node.js 20 deprecation.
+  - Added tests on macOS to the CI.
  </notes>
  <contents>
   <dir name="/">


### PR DESCRIPTION
When pcre2 is installed via Homebrew on macOS, the header file pcre2.h is typically located in the Homebrew include directory. This leads to build errors since the compiler does not use this directory by default. Therefore, the Homebrew include directory is now added as include directory for the compiler if it contains pcre2.h. In addition, the CI has been extended to check the build on macOS.

Closes #572 